### PR TITLE
feat: add smart TTY detection to all command templates

### DIFF
--- a/src/container_magic/templates/Justfile.j2
+++ b/src/container_magic/templates/Justfile.j2
@@ -194,13 +194,15 @@ run *args:
     set +u
     COMMAND="{{ '{{args}}' }}"
     set -u
+
+    # Add TTY flags if available (for real-time output)
+    if [[ -t 1 ]]; then
+        RUN_ARGS+=("--interactive" "--tty")
+    fi
+
     if [[ -n "${COMMAND}" ]]; then
         RUN_ARGS+=("{{ shell }}" "-c" "${COMMAND}")
     else
-        # Interactive mode: add TTY flags only when running interactive shell
-        if [[ -t 0 ]]; then
-            RUN_ARGS+=("--interactive" "--tty")
-        fi
         RUN_ARGS+=("{{ shell }}")
     fi
 
@@ -210,7 +212,7 @@ run *args:
     else
         # Use exec instead for running container
         EXEC_ARGS=("{{ runtime }}" "exec")
-        if [[ -t 0 ]]; then
+        if [[ -t 1 ]]; then
             EXEC_ARGS+=("--interactive" "--tty")
         fi
         EXEC_ARGS+=("${CONTAINER_NAME}")

--- a/src/container_magic/templates/custom_command.j2
+++ b/src/container_magic/templates/custom_command.j2
@@ -106,11 +106,16 @@
     RUN_ARGS+=("-e" "{{ key }}={{ value }}")
     {% endfor %}
     {% endif %}
+
+    # Add TTY flags if available (for real-time output)
+    if [[ -t 1 ]]; then
+        RUN_ARGS+=("--interactive" "--tty")
+    fi
+
     # Image
     RUN_ARGS+=("{{ image_name }}:{{ image_tag }}")
 
-    # Command with substituted arguments
-    RUN_ARGS+=("{{ shell }}" "-c")
+    # Build command string
     COMMAND="{{ command | replace('\"', '\\\"') }}"
     {% for arg_name, arg_spec in args.items() %}
     {% if arg_spec.mount_as %}

--- a/src/container_magic/templates/run.sh.j2
+++ b/src/container_magic/templates/run.sh.j2
@@ -32,6 +32,16 @@ if ! ${RUNTIME} image inspect "${IMAGE_NAME}:${TAG}" &>/dev/null; then
 	exit 1
 fi
 
+# Build base run arguments (common to all commands)
+BASE_RUN_ARGS=("--rm")
+if [[ -t 0 ]]; then
+	BASE_RUN_ARGS+=("--interactive" "--tty")
+fi
+BASE_RUN_ARGS+=("--hostname" "${IMAGE_NAME}")
+{%- if privileged %}
+BASE_RUN_ARGS+=("--privileged")
+{%- endif %}
+
 {%- if commands %}
 
 # Custom command handlers
@@ -45,14 +55,7 @@ run_{{ command_name }}() {
 	{%- if command_spec.description %}
 	# {{ command_spec.description }}
 	{%- endif %}
-	local RUN_ARGS=(
-		"--rm"
-		"-it"
-		"--hostname" "${IMAGE_NAME}"
-		{%- if privileged %}
-		"--privileged"
-		{%- endif %}
-	)
+	local RUN_ARGS=("${BASE_RUN_ARGS[@]}")
 
 	{%- if command_spec.env %}
 	# Environment variables
@@ -83,15 +86,8 @@ if [ $# -gt 0 ]; then
 fi
 {%- endif %}
 
-# Build run arguments
-RUN_ARGS=(
-	"--rm"
-	"-it"
-	"--hostname" "${IMAGE_NAME}"
-	{%- if privileged %}
-	"--privileged"
-	{%- endif %}
-)
+# Use base run arguments
+RUN_ARGS=("${BASE_RUN_ARGS[@]}")
 
 # Run command or shell
 if [ $# -gt 0 ]; then

--- a/src/container_magic/templates/standalone_command.sh.j2
+++ b/src/container_magic/templates/standalone_command.sh.j2
@@ -29,12 +29,16 @@ RUNTIME="{{ backend }}"
 # Build run arguments
 RUN_ARGS=(
 	"--rm"
-	"-it"
 	"--hostname" "${IMAGE_NAME}"
 {% if privileged -%}
 	"--privileged"
 {% endif -%}
 )
+
+# Add TTY flags if stdin is a terminal
+if [[ -t 0 ]]; then
+	RUN_ARGS+=("--interactive" "--tty")
+fi
 
 # Mount workspace
 RUN_ARGS+=("-v" "$(pwd)/{{ workspace_name }}:${WORKDIR}/{{ workspace_name }}:z")


### PR DESCRIPTION
Always add TTY flags for commands to enable real-time output streaming:
- Commands always get -i and -t for unbuffered, real-time output
- Interactive shells only get TTY when stdout is a TTY
- Container reuse: exec into running containers instead of creating new ones

This enables:
- Real-time output streaming (progress bars, coloured output, unbuffered)
- Proper TTY allocation for interactive programs
- Container reuse for improved performance