### PR TITLE
feat: add runtime.network configuration option

### DIFF
--- a/src/container_magic/core/config.py
+++ b/src/container_magic/core/config.py
@@ -133,6 +133,10 @@ class RuntimeConfig(BaseModel):
     privileged: bool = Field(
         default=False, description="Run containers in privileged mode"
     )
+    network: Optional[Literal["host", "bridge", "none"]] = Field(
+        default=None,
+        description="Container network mode (host, bridge, none)",
+    )
     features: List[Literal["display", "gpu", "audio", "aws_credentials"]] = Field(
         default_factory=list, description="Features to enable in containers"
     )

--- a/src/container_magic/generators/justfile.py
+++ b/src/container_magic/generators/justfile.py
@@ -107,6 +107,7 @@ def generate_justfile(
         auto_update=config.project.auto_update,
         runtime=runtime.value,
         privileged=config.runtime.privileged,
+        network=config.runtime.network,
         mount_workspace=True,  # Always mount workspace in development
         shell=shell,
         features=features,
@@ -138,6 +139,7 @@ def generate_justfile(
                 args=command_spec.args,
                 env=merged_env,
                 runtime=runtime.value,
+                network=config.runtime.network,
                 image_name=config.project.name,
                 image_tag="development",
                 shell=shell,

--- a/src/container_magic/generators/run_script.py
+++ b/src/container_magic/generators/run_script.py
@@ -56,6 +56,7 @@ def generate_run_script(config: ContainerMagicConfig, project_dir: Path) -> None
         shell=shell,
         backend=backend,
         privileged=config.runtime.privileged if config.runtime else False,
+        network=config.runtime.network if config.runtime else None,
         commands=commands_escaped,
     )
 

--- a/src/container_magic/generators/standalone_commands.py
+++ b/src/container_magic/generators/standalone_commands.py
@@ -74,6 +74,7 @@ def generate_standalone_command_scripts(
                 shell=shell,
                 backend=backend,
                 privileged=config.runtime.privileged if config.runtime else False,
+                network=config.runtime.network if config.runtime else None,
                 env=command_spec.env,
                 command=command_escaped,
                 workspace_name=config.project.workspace,

--- a/src/container_magic/templates/Justfile.j2
+++ b/src/container_magic/templates/Justfile.j2
@@ -92,7 +92,9 @@ run *args:
     RUN_ARGS+=("{{ runtime }}" "run")
     RUN_ARGS+=("--name" "${CONTAINER_NAME}")
     RUN_ARGS+=("--rm")
-    RUN_ARGS+=("--net" "host")
+    {% if network %}
+    RUN_ARGS+=("--net" "{{ network }}")
+    {% endif %}
 
     {% if runtime == "podman" %}
     # Podman-specific configuration

--- a/src/container_magic/templates/custom_command.j2
+++ b/src/container_magic/templates/custom_command.j2
@@ -34,6 +34,9 @@
     RUN_ARGS+=("{{ runtime }}" "run")
     RUN_ARGS+=("--name" "${CONTAINER_NAME}")
     RUN_ARGS+=("--rm")
+    {% if network %}
+    RUN_ARGS+=("--net" "{{ network }}")
+    {% endif %}
 
     {% if runtime == "podman" %}
     # Podman-specific configuration

--- a/src/container_magic/templates/run.sh.j2
+++ b/src/container_magic/templates/run.sh.j2
@@ -41,6 +41,9 @@ BASE_RUN_ARGS+=("--hostname" "${IMAGE_NAME}")
 {%- if privileged %}
 BASE_RUN_ARGS+=("--privileged")
 {%- endif %}
+{%- if network %}
+BASE_RUN_ARGS+=("--net" "{{ network }}")
+{%- endif %}
 
 {%- if commands %}
 

--- a/src/container_magic/templates/standalone_command.sh.j2
+++ b/src/container_magic/templates/standalone_command.sh.j2
@@ -33,6 +33,9 @@ RUN_ARGS=(
 {% if privileged -%}
 	"--privileged"
 {% endif -%}
+{% if network -%}
+	"--net" "{{ network }}"
+{% endif -%}
 )
 
 # Add TTY flags if stdin is a terminal


### PR DESCRIPTION
- Add network field to RuntimeConfig (host/bridge/none)
- Update all templates to support configurable network mode
- Update generators to pass network config to templates
- Default to None (only set --net when explicitly configured)