### PR TITLE
fix: move TTY flags before image in Justfile run recipe

### DIFF
--- a/src/container_magic/templates/Justfile.j2
+++ b/src/container_magic/templates/Justfile.j2
@@ -188,6 +188,11 @@ run *args:
         RUN_ARGS+=("--workdir={{ container_home }}")
     fi
 
+    # Add TTY flags if available (for real-time output)
+    if [[ -t 1 ]]; then
+        RUN_ARGS+=("--interactive" "--tty")
+    fi
+
     # Image and command
     RUN_ARGS+=("${IMAGE}")
 
@@ -196,11 +201,6 @@ run *args:
     set +u
     COMMAND="{{ '{{args}}' }}"
     set -u
-
-    # Add TTY flags if available (for real-time output)
-    if [[ -t 1 ]]; then
-        RUN_ARGS+=("--interactive" "--tty")
-    fi
 
     if [[ -n "${COMMAND}" ]]; then
         RUN_ARGS+=("{{ shell }}" "-c" "${COMMAND}")


### PR DESCRIPTION
TTY flags (--interactive, --tty) were added to RUN_ARGS after the image name, causing container runtimes to interpret --interactive as the command to execute.

Adds regression test to validate flag ordering.