### PR TITLE
feat(commands): add port publishing support

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,12 @@ commands:
     command: bash workspace/deploy.sh
     description: Deploy the model
     standalone: true   # Generates deploy.sh script
+
+  serve:
+    command: python -m http.server 8000
+    description: Start dev server
+    ports:
+      - "8000:8000"
 ```
 
 **Command options:**
@@ -223,6 +229,7 @@ commands:
 - `description` - Help text shown in Justfile
 - `args` - Positional arguments (see below)
 - `env` - Environment variables passed to the container
+- `ports` - Ports to publish to the host (`host:container` format, generates `--publish` flags)
 - `standalone` - Generate a dedicated `<command>.sh` script
 
 ### Command Arguments

--- a/src/container_magic/core/config.py
+++ b/src/container_magic/core/config.py
@@ -233,6 +233,10 @@ class CustomCommand(BaseModel):
     env: Dict[str, str] = Field(
         default_factory=dict, description="Environment variables"
     )
+    ports: List[str] = Field(
+        default_factory=list,
+        description="Ports to publish (host:container format)",
+    )
     standalone: bool = Field(
         default=False,
         description="Generate standalone script for this command",

--- a/src/container_magic/generators/justfile.py
+++ b/src/container_magic/generators/justfile.py
@@ -143,6 +143,7 @@ def generate_justfile(
                 command=command_escaped,
                 args=command_spec.args,
                 env=merged_env,
+                ports=command_spec.ports,
                 runtime=runtime.value,
                 network=config.runtime.network,
                 image_name=config.project.name,

--- a/src/container_magic/generators/standalone_commands.py
+++ b/src/container_magic/generators/standalone_commands.py
@@ -76,6 +76,7 @@ def generate_standalone_command_scripts(
                 privileged=config.runtime.privileged if config.runtime else False,
                 network=config.runtime.network if config.runtime else None,
                 env=command_spec.env,
+                ports=command_spec.ports,
                 command=command_escaped,
                 workspace_name=config.project.workspace,
             )

--- a/src/container_magic/templates/custom_command.j2
+++ b/src/container_magic/templates/custom_command.j2
@@ -137,6 +137,13 @@
     RUN_ARGS+=("-e" "{{ key }}={{ value }}")
     {% endfor %}
     {% endif %}
+    {% if ports %}
+
+    # Port publishing
+    {% for port in ports %}
+    RUN_ARGS+=("--publish" "{{ port }}")
+    {% endfor %}
+    {% endif %}
 
     # Add TTY flags if available (for real-time output)
     if [[ -t 1 ]]; then

--- a/src/container_magic/templates/run.sh.j2
+++ b/src/container_magic/templates/run.sh.j2
@@ -63,6 +63,12 @@ run_{{ command_name }}() {
 	RUN_ARGS+=("-e" "{{ key }}={{ value }}")
 	{%- endfor %}
 	{%- endif %}
+	{%- if command_spec.ports %}
+	# Port publishing
+	{%- for port in command_spec.ports %}
+	RUN_ARGS+=("--publish" "{{ port }}")
+	{%- endfor %}
+	{%- endif %}
 
 	${RUNTIME} run "${RUN_ARGS[@]}" \
 		-w "${WORKDIR}" \

--- a/src/container_magic/templates/standalone_command.sh.j2
+++ b/src/container_magic/templates/standalone_command.sh.j2
@@ -52,6 +52,13 @@ RUN_ARGS+=("-v" "$(pwd)/{{ workspace_name }}:${WORKDIR}/{{ workspace_name }}:z")
 RUN_ARGS+=("-e" "{{ key }}={{ value }}")
 {% endfor -%}
 {% endif -%}
+{% if ports -%}
+
+# Port publishing
+{% for port in ports -%}
+RUN_ARGS+=("--publish" "{{ port }}")
+{% endfor -%}
+{% endif -%}
 
 # Check if image exists
 if ! ${RUNTIME} image inspect "${IMAGE_NAME}:${TAG}" >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- Add `ports` field to command config, generating `--publish` flags for container run arguments
- Supported in Justfile commands, standalone scripts, and production run.sh handlers
- Allows commands running servers to expose ports without requiring `runtime.network: host`

## Tests
- New integration test `test_custom_commands_with_ports` verifies `--publish` flags in Justfile and run.sh
- Manually verified port forwarding works with a dev server command