### PR TITLE
feat(steps): add user-aware copy steps and become_user/become_root aliases

### DIFF
--- a/src/container_magic/cli/main.py
+++ b/src/container_magic/cli/main.py
@@ -204,7 +204,7 @@ def init(
         },
         stages={
             "base": {"from": base_image, "steps": ["create_user"]},
-            "development": {"from": "base", "steps": ["switch_user"]},
+            "development": {"from": "base", "steps": ["become_user"]},
             "production": {"from": "base"},
         },
     )

--- a/src/container_magic/core/config.py
+++ b/src/container_magic/core/config.py
@@ -197,7 +197,7 @@ class StageConfig(BaseModel):
     )
     steps: Optional[List[str]] = Field(
         default=None,
-        description="Ordered list of build steps with special keywords: install_system_packages, install_pip_packages, create_user, switch_user, switch_root, copy_cached_assets, copy_workspace",
+        description="Ordered list of build steps with special keywords: install_system_packages, install_pip_packages, create_user, become_user, become_root, copy, copy_as_user, copy_as_root, copy_cached_assets, copy_workspace (aliases: switch_user, switch_root)",
         alias="build_steps",  # Support old name for backwards compatibility
     )
 
@@ -423,7 +423,7 @@ class ContainerMagicConfig(BaseModel):
             ),
             (
                 "    steps:",
-                "    # Build steps: install_system_packages, install_pip_packages, create_user, switch_user, copy_cached_assets, copy_workspace\n    steps:",
+                "    # Build steps: install_system_packages, install_pip_packages, create_user, become_user, become_root, copy, copy_as_user, copy_as_root, copy_cached_assets, copy_workspace\n    steps:",
             ),
             (
                 "  production:",

--- a/src/container_magic/templates/Dockerfile.j2
+++ b/src/container_magic/templates/Dockerfile.j2
@@ -137,6 +137,12 @@ COPY --chown=${USER_UID}:${USER_GID} {{ workspace_name }} ${WORKSPACE}
 {% else %}
 COPY {{ workspace_name }} ${WORKSPACE}
 {% endif %}
+{% elif step.type == "copy" %}
+{% if step.chown %}
+COPY --chown=${USER_UID}:${USER_GID} {{ step.args }}
+{% else %}
+COPY {{ step.args }}
+{% endif %}
 {% elif step.type == "custom" %}
 {% if step.command.startswith('COPY ') or step.command.startswith('ADD ') or step.command.startswith('ENV ') or step.command.startswith('WORKDIR ') or step.command.startswith('USER ') or step.command.startswith('LABEL ') or step.command.startswith('EXPOSE ') or step.command.startswith('VOLUME ') or step.command.startswith('RUN ') %}
 {{ step.command }}


### PR DESCRIPTION
## Summary

- Adds `copy` step — context-aware COPY that automatically applies `--chown=${USER_UID}:${USER_GID}` when `become_user` is active
- Adds `copy_as_user` step — always applies `--chown`, regardless of current context
- Adds `copy_as_root` step — never applies `--chown`, regardless of current context
- Adds `become_user` / `become_root` as preferred aliases for `switch_user` / `switch_root` (old forms still work)
- Updates all documentation and examples to use new preferred terminology
- Updates `cm init` to generate `become_user` in default configs

These additions give users a complete lowercase vocabulary for build steps — no need to drop to raw Dockerfile syntax for common operations. Uppercase `COPY` remains available as raw passthrough.

Backwards compatible: `switch_user` and `switch_root` continue to work as aliases.