### PR TITLE
ci: skip PyPI publish when no release is created

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,8 @@ jobs:
     permissions:
       id-token: write
       contents: write
+    outputs:
+      released: ${{ steps.semantic.outputs.released }}
 
     steps:
       - uses: actions/checkout@v4
@@ -70,15 +72,24 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Release
+        id: semantic
         env:
           GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         run: |
-          semantic-release version
-          semantic-release publish
+          if semantic-release version; then
+            if git diff --name-only HEAD~1 HEAD | grep -q pyproject.toml; then
+              echo "released=true" >> "$GITHUB_OUTPUT"
+              semantic-release publish
+            else
+              echo "released=false" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            echo "released=false" >> "$GITHUB_OUTPUT"
+          fi
 
   publish-pypi:
     needs: release
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.release.outputs.released == 'true'
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -87,6 +98,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: main
 
       - name: Set up Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
## Summary

- The `publish-pypi` job ran unconditionally after the `release` job, causing failures when docs/chore commits produced no version bump (e.g. the docs PR #13)
- Add an `outputs.released` flag to the `release` job that checks whether `semantic-release version` actually bumped `pyproject.toml`
- Gate `publish-pypi` on `needs.release.outputs.released == 'true'`
- Only call `semantic-release publish` when a version was actually created