### PR TITLE
ci: add GitHub Pages deployment for docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,46 @@
+name: Deploy docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+
+permissions:
+  pages: write
+  id-token: write
+
+concurrency:
+  group: deploy-docs
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install MkDocs Material
+        run: pip install mkdocs-material
+
+      - name: Build docs
+        run: mkdocs build --strict
+
+      - name: Upload pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -70,16 +70,16 @@ stages:
 
 ## Documentation
 
-Full documentation is available at **[markhedleyjones.github.io/container-magic](https://markhedleyjones.github.io/container-magic/)**.
+Full documentation is available at **[markhedleyjones.com/container-magic](https://markhedleyjones.com/container-magic/)**.
 
 | Page | Contents |
 |------|----------|
-| [Getting Started](https://markhedleyjones.github.io/container-magic/getting-started/) | Installation, first project, workflow, project structure |
-| [Configuration](https://markhedleyjones.github.io/container-magic/configuration/) | Full YAML reference — project, runtime, user, stages, commands |
-| [Build Steps](https://markhedleyjones.github.io/container-magic/build-steps/) | All 10 built-in steps, custom commands, defaults, ordering |
-| [Cached Assets](https://markhedleyjones.github.io/container-magic/cached-assets/) | Asset downloading, caching, and cache management |
-| [User Handling](https://markhedleyjones.github.io/container-magic/user-handling/) | Dev vs prod users, copy ownership, permissions |
-| [Troubleshooting](https://markhedleyjones.github.io/container-magic/troubleshooting/) | Common issues and solutions |
+| [Getting Started](https://markhedleyjones.com/container-magic/getting-started/) | Installation, first project, workflow, project structure |
+| [Configuration](https://markhedleyjones.com/container-magic/configuration/) | Full YAML reference — project, runtime, user, stages, commands |
+| [Build Steps](https://markhedleyjones.com/container-magic/build-steps/) | All 10 built-in steps, custom commands, defaults, ordering |
+| [Cached Assets](https://markhedleyjones.com/container-magic/cached-assets/) | Asset downloading, caching, and cache management |
+| [User Handling](https://markhedleyjones.com/container-magic/user-handling/) | Dev vs prod users, copy ownership, permissions |
+| [Troubleshooting](https://markhedleyjones.com/container-magic/troubleshooting/) | Common issues and solutions |
 
 ## Contributing
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: container-magic
-site_url: https://markhedleyjones.github.io/container-magic
+site_url: https://markhedleyjones.com/container-magic
 site_description: Rapidly create containerised development environments
 repo_url: https://github.com/markhedleyjones/container-magic
 repo_name: markhedleyjones/container-magic


### PR DESCRIPTION
## Summary

- Add `.github/workflows/docs.yml` that builds MkDocs and deploys to GitHub Pages using the official `deploy-pages` action
- Only triggers on pushes to main that touch `docs/` or `mkdocs.yml`
- Update `site_url` in mkdocs.yml and all README links from `markhedleyjones.github.io` to `markhedleyjones.com` (custom domain redirect)