### PR TITLE
ci: fix duplicate PyPI publish on release commits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,8 @@ jobs:
 
   release:
     needs: test
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && !startsWith(github.event.head_commit.message, 'chore(release)')
+
     runs-on: ubuntu-latest
     concurrency: release
     permissions:
@@ -79,7 +80,6 @@ jobs:
           if semantic-release version; then
             if git diff --name-only HEAD~1 HEAD | grep -q pyproject.toml; then
               echo "released=true" >> "$GITHUB_OUTPUT"
-              semantic-release publish
             else
               echo "released=false" >> "$GITHUB_OUTPUT"
             fi


### PR DESCRIPTION
## Summary

- Skip the release and publish-pypi jobs when the commit message starts with `chore(release)` — prevents the release commit from triggering a second CI run that tries to re-upload to PyPI
- Remove the redundant `semantic-release publish` call from the release job — the config has `upload_to_pypi = false`, and the `publish-pypi` job with `pypa/gh-action-pypi-publish` (trusted publishing) is the sole upload path