### PR TITLE
fix(templates): Jinja2 force variable, Podman name filter, TTY detection

### DIFF
--- a/src/container_magic/templates/Justfile.j2
+++ b/src/container_magic/templates/Justfile.j2
@@ -30,7 +30,7 @@ _check-config force="":
         auto_update_off=$(grep -E '^\s*auto_update:\s*false' "$config_file" || echo "")
 
         if [ -n "$auto_update_off" ]; then
-            if [ "{{ force }}" != "--force" ]; then
+            if [ "{{ '{{force}}' }}" != "--force" ]; then
                 echo "⚠️  $config_file has changed since last generation"
                 echo "   Run 'cm update' to regenerate Justfile and Dockerfile"
                 echo "   Or use --force to build anyway"
@@ -253,7 +253,7 @@ run *args:
         fi
 
         # Check if container already running
-        if ! {{ runtime }} ps --quiet --filter name="${CONTAINER_NAME}" | grep -q .; then
+        if ! {{ runtime }} ps --quiet --filter name="^${CONTAINER_NAME}$" | grep -q .; then
             "${RUN_ARGS[@]}"
         else
             # Use exec instead for running container

--- a/src/container_magic/templates/custom_command.j2
+++ b/src/container_magic/templates/custom_command.j2
@@ -172,7 +172,7 @@
     {% endif %}
 
     # Add TTY flags if available (for real-time output)
-    if [[ -t 1 ]]; then
+    if [[ -t 0 ]]; then
         RUN_ARGS+=("--interactive" "--tty")
     fi
 
@@ -205,14 +205,14 @@
     fi
 
     # Check if container already running
-    if ! {{ runtime }} ps --quiet --filter name="${CONTAINER_NAME}" | grep -q .; then
+    if ! {{ runtime }} ps --quiet --filter name="^${CONTAINER_NAME}$" | grep -q .; then
         # Start new container
         RUN_ARGS+=("{{ shell }}" "-c" "${COMMAND}")
         "${RUN_ARGS[@]}"
     else
         # Exec into existing container
         EXEC_ARGS=("{{ runtime }}" "exec")
-        if [[ -t 1 ]]; then
+        if [[ -t 0 ]]; then
             EXEC_ARGS+=("--interactive" "--tty")
         fi
         EXEC_ARGS+=("${CONTAINER_NAME}")


### PR DESCRIPTION
Three bug fixes in generated script templates:

- **Justfile force flag**: `{{ force }}` was consumed by Jinja2 at generation time (rendered as empty string). Escaped as `{{ '{{force}}' }}` to produce a literal Just variable, matching the pattern used elsewhere in the template.
- **Podman container name matching**: `--filter name=X` does substring matching in Podman, so a container named `foo` would match `foobar`. Anchored with `^X$` in both `Justfile.j2` and `custom_command.j2`.
- **TTY detection in custom_command**: Used `-t 1` (stdout) while all other templates use `-t 0` (stdin). Standardised to `-t 0` in both places.