### PR TITLE
fix(ci): replace flaky just installation with setup-just action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,7 @@ jobs:
           pip install -e ".[dev]"
 
       - name: Install just
-        run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to /usr/local/bin
+        uses: extractions/setup-just@v3
 
       - name: Run tests
         run: |
@@ -56,8 +55,7 @@ jobs:
           pip install -e ".[dev]"
 
       - name: Install just
-        run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to /usr/local/bin
+        uses: extractions/setup-just@v3
 
       - name: Run build tests
         run: |


### PR DESCRIPTION
The curl-based install from just.systems/install.sh intermittently returns HTTP 403, causing CI reruns. Use extractions/setup-just@v3 which downloads from GitHub Releases instead.