### PR TITLE
fix: add missing .env and privileged support to production templates

### DIFF
--- a/src/container_magic/generators/justfile.py
+++ b/src/container_magic/generators/justfile.py
@@ -123,6 +123,7 @@ def generate_justfile(
                 features=features,
                 volumes=config.runtime.volumes,
                 devices=config.runtime.devices,
+                privileged=config.runtime.privileged if config.runtime else False,
                 ipc=command_spec.ipc
                 or (config.runtime.ipc if config.runtime else None),
                 workspace_symlinks=workspace_symlinks,

--- a/src/container_magic/templates/custom_command.j2
+++ b/src/container_magic/templates/custom_command.j2
@@ -55,6 +55,11 @@
     RUN_ARGS+=("--userns=keep-id")
     RUN_ARGS+=("--env-host=false")
     {% endif %}
+    {% if privileged %}
+
+    # Privileged mode
+    RUN_ARGS+=("--privileged")
+    {% endif %}
 
     # Mount workspace
     RUN_ARGS+=("-v" "$(pwd)/{{ workspace_name }}:{{ container_home }}/{{ workspace_name }}:z")

--- a/src/container_magic/templates/run.sh.j2
+++ b/src/container_magic/templates/run.sh.j2
@@ -166,6 +166,11 @@ if [[ -d "$HOME/.aws" ]]; then
 fi
 {%- endif %}
 
+# Load .env file if present
+if [[ -f "$(pwd)/.env" ]]; then
+	BASE_RUN_ARGS+=("--env-file" "$(pwd)/.env")
+fi
+
 {%- if commands %}
 
 # Custom command handlers


### PR DESCRIPTION
- run.sh.j2 was missing .env file loading via `--env-file` that all other templates (Justfile, custom commands, standalone commands) already had
- custom_command.j2 was missing the `--privileged` flag, and the render context in justfile.py never passed the `privileged` variable to it