### PR TITLE
fix: add SELinux labels to display and audio feature mounts

### DIFF
--- a/src/container_magic/core/runner.py
+++ b/src/container_magic/core/runner.py
@@ -57,7 +57,7 @@ def _add_display_args(args: List[str], runtime: Runtime) -> Optional[str]:
         wayland_socket = f"{xdg_runtime_dir}/{wayland_display}"
         args.extend(["-e", "WAYLAND_DISPLAY"])
         args.extend(["-e", f"XDG_RUNTIME_DIR={xdg_runtime_dir}"])
-        args.extend(["-v", f"{wayland_socket}:{wayland_socket}"])
+        args.extend(["-v", f"{wayland_socket}:{wayland_socket}:z"])
 
     display = os.environ.get("DISPLAY")
     if display:
@@ -97,7 +97,7 @@ def _add_display_args(args: List[str], runtime: Runtime) -> Optional[str]:
                 pass
 
         args.extend(["-e", "DISPLAY"])
-        args.extend(["-v", f"{xsock}:{xsock}"])
+        args.extend(["-v", f"{xsock}:{xsock}:z"])
         args.extend(["--env", "QT_X11_NO_MITSHM=1"])
 
     return xauth_file
@@ -124,7 +124,7 @@ def _add_audio_args(args: List[str]) -> None:
     uid = os.getuid()
     pulse_socket = f"/run/user/{uid}/pulse/native"
     if Path(pulse_socket).is_socket():
-        args.extend(["-v", f"{pulse_socket}:{pulse_socket}"])
+        args.extend(["-v", f"{pulse_socket}:{pulse_socket}:z"])
         args.extend(["-e", f"PULSE_SERVER=unix:{pulse_socket}"])
 
 

--- a/src/container_magic/templates/run.sh.j2
+++ b/src/container_magic/templates/run.sh.j2
@@ -121,12 +121,13 @@ if [[ -n "${WAYLAND_DISPLAY:-}" ]]; then
 	wayland_socket="${XDG_RUNTIME_DIR}/${WAYLAND_DISPLAY}"
 	BASE_RUN_ARGS+=("-e" "WAYLAND_DISPLAY")
 	BASE_RUN_ARGS+=("-e" "XDG_RUNTIME_DIR=${XDG_RUNTIME_DIR}")
-	BASE_RUN_ARGS+=("-v" "${wayland_socket}:${wayland_socket}")
+	BASE_RUN_ARGS+=("-v" "${wayland_socket}:${wayland_socket}:z")
 fi
 if [[ -n "${DISPLAY:-}" ]]; then
 	xsock=/tmp/.X11-unix
 {%- if backend == "auto" %}
 	if [[ "${RUNTIME}" == "podman" ]]; then
+		BASE_RUN_ARGS+=("--security-opt=label=disable")
 		xauth=/tmp/.docker.xauth
 		touch "$xauth"
 		if [[ -f "$HOME/.Xauthority" ]]; then
@@ -139,6 +140,7 @@ if [[ -n "${DISPLAY:-}" ]]; then
 		XHOST_CLEANUP=true
 	fi
 {%- elif backend == "podman" %}
+	BASE_RUN_ARGS+=("--security-opt=label=disable")
 	xauth=/tmp/.docker.xauth
 	touch "$xauth"
 	if [[ -f "$HOME/.Xauthority" ]]; then
@@ -151,7 +153,7 @@ if [[ -n "${DISPLAY:-}" ]]; then
 	XHOST_CLEANUP=true
 {%- endif %}
 	BASE_RUN_ARGS+=("-e" "DISPLAY")
-	BASE_RUN_ARGS+=("-v" "${xsock}:${xsock}")
+	BASE_RUN_ARGS+=("-v" "${xsock}:${xsock}:z")
 	BASE_RUN_ARGS+=("--env" "QT_X11_NO_MITSHM=1")
 fi
 if [[ "${XHOST_CLEANUP}" == true ]] && [[ "${DETACH}" != true ]]; then
@@ -179,7 +181,7 @@ fi
 
 # Audio support (PulseAudio/PipeWire)
 if [[ -S "/run/user/$(id -u)/pulse/native" ]]; then
-	BASE_RUN_ARGS+=("-v" "/run/user/$(id -u)/pulse/native:/run/user/$(id -u)/pulse/native")
+	BASE_RUN_ARGS+=("-v" "/run/user/$(id -u)/pulse/native:/run/user/$(id -u)/pulse/native:z")
 	BASE_RUN_ARGS+=("-e" "PULSE_SERVER=unix:/run/user/$(id -u)/pulse/native")
 fi
 {%- endif %}


### PR DESCRIPTION
Wayland, X11, and PulseAudio socket mounts lacked :z SELinux labels in both runner.py and run.sh.j2. Also adds missing --security-opt label=disable to Podman display blocks in run.sh.j2, matching what runner.py already had.