### PR TITLE
fix: add SELinux :z labels to runtime volumes

### DIFF
--- a/src/container_magic/core/runner.py
+++ b/src/container_magic/core/runner.py
@@ -16,6 +16,7 @@ from container_magic.core.config import ContainerMagicConfig, CustomCommand
 from container_magic.core.runtime import Runtime, get_runtime
 from container_magic.core.symlinks import scan_workspace_symlinks
 from container_magic.core.templates import detect_shell, resolve_base_image
+from container_magic.core.volumes import ensure_selinux_label
 
 
 def _detect_container_home() -> str:
@@ -326,7 +327,7 @@ def run_container(
 
     # Additional volumes
     for volume in config.runtime.volumes:
-        run_args.extend(["-v", volume])
+        run_args.extend(["-v", ensure_selinux_label(volume)])
 
     # Device passthrough
     for device in config.runtime.devices:

--- a/src/container_magic/core/volumes.py
+++ b/src/container_magic/core/volumes.py
@@ -1,0 +1,33 @@
+"""Volume string helpers for SELinux labelling."""
+
+from typing import List
+
+
+def ensure_selinux_label(volume: str) -> str:
+    """Append an SELinux :z label to a volume string if not already present.
+
+    Handles the standard host:container[:options] format:
+    - /host:/container          -> /host:/container:z
+    - /host:/container:ro       -> /host:/container:ro,z
+    - /host:/container:z        -> unchanged
+    - /host:/container:ro,z     -> unchanged
+    - /host:/container:Z        -> unchanged
+    """
+    parts = volume.split(":")
+    if len(parts) < 2:
+        return volume
+
+    if len(parts) == 2:
+        return volume + ":z"
+
+    options = parts[-1]
+    option_tokens = [t.strip() for t in options.split(",")]
+    if "z" in option_tokens or "Z" in option_tokens:
+        return volume
+
+    return volume + ",z"
+
+
+def label_volumes(volumes: List[str]) -> List[str]:
+    """Apply SELinux labelling to a list of volume strings."""
+    return [ensure_selinux_label(v) for v in volumes]

--- a/src/container_magic/generators/run_script.py
+++ b/src/container_magic/generators/run_script.py
@@ -8,6 +8,7 @@ from jinja2 import Environment, PackageLoader
 from container_magic.core.config import ContainerMagicConfig
 from container_magic.core.steps import has_create_user_in_stages
 from container_magic.core.templates import detect_shell, resolve_base_image
+from container_magic.core.volumes import label_volumes
 
 
 def generate_run_script(config: ContainerMagicConfig, project_dir: Path) -> None:
@@ -70,7 +71,7 @@ def generate_run_script(config: ContainerMagicConfig, project_dir: Path) -> None
         privileged=config.runtime.privileged if config.runtime else False,
         network=config.runtime.network_mode if config.runtime else None,
         features=features,
-        volumes=config.runtime.volumes if config.runtime else [],
+        volumes=label_volumes(config.runtime.volumes) if config.runtime else [],
         devices=config.runtime.devices if config.runtime else [],
         commands=commands_escaped,
         ipc=config.runtime.ipc if config.runtime else None,

--- a/tests/integration/test_config_variations.py
+++ b/tests/integration/test_config_variations.py
@@ -458,6 +458,6 @@ def test_volumes_and_devices_appear_in_generated_files(fixtures_dir, temp_projec
     assert result.returncode == 0, f"cm update failed:\n{result.stderr}"
 
     run_sh = (temp_project / "run.sh").read_text()
-    assert '"-v" "/tmp/test-data:/data:ro"' in run_sh
-    assert '"-v" "/var/log/app:/logs"' in run_sh
+    assert '"-v" "/tmp/test-data:/data:ro,z"' in run_sh
+    assert '"-v" "/var/log/app:/logs:z"' in run_sh
     assert '"--device" "/dev/ttyUSB0"' in run_sh

--- a/tests/unit/test_volumes.py
+++ b/tests/unit/test_volumes.py
@@ -1,0 +1,59 @@
+"""Unit tests for volume SELinux labelling."""
+
+from container_magic.core.volumes import ensure_selinux_label, label_volumes
+
+
+class TestEnsureSelinuxLabel:
+    def test_no_options(self):
+        assert ensure_selinux_label("/host:/container") == "/host:/container:z"
+
+    def test_ro_option(self):
+        assert ensure_selinux_label("/host:/container:ro") == "/host:/container:ro,z"
+
+    def test_rw_option(self):
+        assert ensure_selinux_label("/host:/container:rw") == "/host:/container:rw,z"
+
+    def test_already_has_z(self):
+        assert ensure_selinux_label("/host:/container:z") == "/host:/container:z"
+
+    def test_already_has_ro_z(self):
+        assert ensure_selinux_label("/host:/container:ro,z") == "/host:/container:ro,z"
+
+    def test_already_has_uppercase_z(self):
+        assert ensure_selinux_label("/host:/container:Z") == "/host:/container:Z"
+
+    def test_already_has_ro_uppercase_z(self):
+        assert ensure_selinux_label("/host:/container:ro,Z") == "/host:/container:ro,Z"
+
+    def test_single_part_unchanged(self):
+        assert ensure_selinux_label("named-volume") == "named-volume"
+
+    def test_z_in_middle_of_options(self):
+        assert ensure_selinux_label("/host:/container:z,ro") == "/host:/container:z,ro"
+
+    def test_complex_path_with_colons(self):
+        result = ensure_selinux_label("/host/path:/container/path:ro")
+        assert result == "/host/path:/container/path:ro,z"
+
+    def test_named_volume(self):
+        assert ensure_selinux_label("myvolume:/container/path") == "myvolume:/container/path:z"
+
+    def test_compound_options_with_nocopy(self):
+        assert ensure_selinux_label("/host:/container:ro,nocopy") == "/host:/container:ro,nocopy,z"
+
+
+class TestLabelVolumes:
+    def test_empty_list(self):
+        assert label_volumes([]) == []
+
+    def test_mixed_volumes(self):
+        result = label_volumes([
+            "/tmp/data:/data:ro",
+            "/var/log:/logs",
+            "/host:/container:z",
+        ])
+        assert result == [
+            "/tmp/data:/data:ro,z",
+            "/var/log:/logs:z",
+            "/host:/container:z",
+        ]


### PR DESCRIPTION
Runtime volumes were passed through verbatim without SELinux relabelling, causing permission denied on Fedora/RHEL. Command-level mounts already had :z. New volumes module handles all format variants (bare, with options, already labelled).