### PR TITLE
fix: run custom commands from workspace directory

### DIFF
--- a/src/container_magic/core/runner.py
+++ b/src/container_magic/core/runner.py
@@ -414,8 +414,10 @@ def run_container(
         # (pipes, &&, variable expansion) use: cm run bash -c "..."
         pass
 
-    # Working directory
-    workdir = _translate_workdir(project_dir, user_cwd, container_home)
+    if command_spec:
+        workdir = f"{container_home}/{workspace_name}"
+    else:
+        workdir = _translate_workdir(project_dir, user_cwd, container_home)
     run_args.extend(["--workdir", workdir])
 
     # Determine how to append the command to run_args:

--- a/src/container_magic/templates/run.sh.j2
+++ b/src/container_magic/templates/run.sh.j2
@@ -296,12 +296,12 @@ run_{{ command_name }}() {
 	if [[ ${#EXTRA_ARGS[@]} -gt 0 ]]; then
 	{%- endraw %}
 		${RUNTIME} run "${RUN_ARGS[@]}" \
-			-w "${WORKDIR}" \
+			-w "${WORKDIR}/${WORKSPACE_NAME}" \
 			"${IMAGE_NAME}:${TAG}" \
 			"${SHELL}" -c "${CMD} $(printf '%q ' "${EXTRA_ARGS[@]}")"
 	else
 		${RUNTIME} run "${RUN_ARGS[@]}" \
-			-w "${WORKDIR}" \
+			-w "${WORKDIR}/${WORKSPACE_NAME}" \
 			"${IMAGE_NAME}:${TAG}" \
 			"${SHELL}" -c "${CMD}"
 	fi

--- a/tests/integration/test_custom_commands.py
+++ b/tests/integration/test_custom_commands.py
@@ -133,9 +133,9 @@ def test_no_custom_commands_section_when_empty(temp_project_dir):
     )
 
 
-def test_custom_commands_use_workdir_not_workspace(temp_project_dir):
-    """Test that custom commands use WORKDIR (not WORKDIR/WORKSPACE) as working directory."""
-    # Initialize project
+def test_custom_commands_use_workspace_as_workdir(temp_project_dir):
+    """Test that custom commands use WORKDIR/WORKSPACE as working directory."""
+    # Initialise project
     result = subprocess.run(
         ["cm", "init", "--here", "python"],
         cwd=temp_project_dir,
@@ -151,7 +151,7 @@ def test_custom_commands_use_workdir_not_workspace(temp_project_dir):
     custom_commands = """
 commands:
   daemon:
-    command: "python workspace/daemon.py"
+    command: "python daemon.py"
     description: "Run daemon"
 """
     config_file.write_text(config_content + custom_commands)
@@ -165,11 +165,8 @@ commands:
     )
     assert result.returncode == 0, f"cm update failed: {result.stderr}"
 
-    # Check run.sh uses WORKDIR (not WORKDIR/WORKSPACE) for custom commands
     run_sh_content = (temp_project_dir / "run.sh").read_text()
 
-    # Should use -w "${WORKDIR}" not -w "${WORKDIR}/${WORKSPACE_NAME}" in custom commands
-    # Look for the pattern in the run_daemon function
     import re
 
     daemon_match = re.search(
@@ -178,12 +175,12 @@ commands:
     assert daemon_match, "Could not find run_daemon function"
     daemon_function = daemon_match.group(0)
 
-    assert '-w "${WORKDIR}"' in daemon_function, (
-        "Custom command should use WORKDIR as working directory"
+    assert '-w "${WORKDIR}/${WORKSPACE_NAME}"' in daemon_function, (
+        "Custom command should use WORKDIR/WORKSPACE as working directory"
     )
-    assert '-w "${WORKDIR}/${WORKSPACE_NAME}"' not in daemon_function, (
-        "Custom command should not use WORKDIR/WORKSPACE"
-    )
+    assert (
+        daemon_function.count('-w "${WORKDIR}/${WORKSPACE_NAME}"') == 2
+    ), "Both branches (with and without extra args) should use workspace workdir"
 
 
 def test_run_sh_shellcheck_validation_with_commands(temp_project_dir):


### PR DESCRIPTION
Custom commands defined in the commands block ran with working directory set to the user's home, forcing cd boilerplate. Ad-hoc and interactive commands already defaulted to the workspace. Now all commands are consistent.