### PR TITLE
test: add linter validation for generated Dockerfiles and shell scripts

### DIFF
--- a/src/container_magic/templates/Dockerfile.j2
+++ b/src/container_magic/templates/Dockerfile.j2
@@ -46,18 +46,18 @@ RUN if [ "${USER_NAME}" != "root" ]; then \
                 # Rename the existing user to our desired name
                 echo "Renaming user ${EXISTING_USER} to ${USER_NAME}"; \
                 deluser "${EXISTING_USER}"; \
-                addgroup -g ${USER_GID} ${USER_NAME} 2>/dev/null || true; \
-                adduser -D -u ${USER_UID} -G ${USER_NAME} -h ${USER_HOME} ${USER_NAME}; \
+                addgroup -g "${USER_GID}" "${USER_NAME}" 2>/dev/null || true; \
+                adduser -D -u "${USER_UID}" -G "${USER_NAME}" -h "${USER_HOME}" "${USER_NAME}"; \
             else \
                 # Create new user
-                if ! getent group ${USER_GID} >/dev/null 2>&1; then \
-                    addgroup -g ${USER_GID} ${USER_NAME}; \
+                if ! getent group "${USER_GID}" >/dev/null 2>&1; then \
+                    addgroup -g "${USER_GID}" "${USER_NAME}"; \
                 fi && \
-                adduser -D -u ${USER_UID} -G ${USER_NAME} -h ${USER_HOME} ${USER_NAME}; \
+                adduser -D -u "${USER_UID}" -G "${USER_NAME}" -h "${USER_HOME}" "${USER_NAME}"; \
             fi \
         fi && \
         # Ensure home directory ownership (may have been created by WORKDIR)
-        chown ${USER_UID}:${USER_GID} ${USER_HOME}; \
+        chown "${USER_UID}:${USER_GID}" "${USER_HOME}"; \
     fi
 {% else %}
 RUN if [ "${USER_NAME}" != "root" ]; then \
@@ -70,18 +70,18 @@ RUN if [ "${USER_NAME}" != "root" ]; then \
             if [ -n "${EXISTING_USER}" ] && [ "${EXISTING_USER}" != "${USER_NAME}" ]; then \
                 # Rename the existing user to our desired name
                 echo "Renaming user ${EXISTING_USER} to ${USER_NAME}"; \
-                usermod -l ${USER_NAME} ${EXISTING_USER} && \
-                usermod -d ${USER_HOME} -m ${USER_NAME} || true; \
+                usermod -l "${USER_NAME}" "${EXISTING_USER}" && \
+                usermod -d "${USER_HOME}" -m "${USER_NAME}" || true; \
             else \
                 # Create new user
-                if ! getent group ${USER_GID} >/dev/null 2>&1; then \
-                    groupadd --gid ${USER_GID} ${USER_NAME}; \
+                if ! getent group "${USER_GID}" >/dev/null 2>&1; then \
+                    groupadd --gid "${USER_GID}" "${USER_NAME}"; \
                 fi && \
-                useradd --uid ${USER_UID} --gid ${USER_GID} --home-dir ${USER_HOME} --create-home ${USER_NAME}; \
+                useradd --uid "${USER_UID}" --gid "${USER_GID}" --home-dir "${USER_HOME}" --create-home "${USER_NAME}"; \
             fi \
         fi && \
         # Ensure home directory ownership (may have been created by WORKDIR)
-        chown ${USER_UID}:${USER_GID} ${USER_HOME}; \
+        chown "${USER_UID}:${USER_GID}" "${USER_HOME}"; \
     fi
 {% endif %}
 {% elif step.type == "create_user_literal" %}

--- a/src/container_magic/templates/build.sh.j2
+++ b/src/container_magic/templates/build.sh.j2
@@ -64,19 +64,19 @@ while [[ $# -gt 0 ]]; do
 done
 
 echo "Building image: ${IMAGE_NAME}:${TAG} (target: ${TARGET})"
-{% if workspace_symlinks %}
+{%- if workspace_symlinks %}
 
 # Stage resolved symlink targets for Docker build context
 STAGING_DIR=".cm-cache/staging"
 rm -rf "${STAGING_DIR}"
 trap 'rm -rf "${STAGING_DIR}"' EXIT
 
-{% for rel_path in workspace_symlinks %}
+{% for rel_path in workspace_symlinks -%}
 echo "Staging symlink: {{ workspace_name }}/{{ rel_path }}"
 mkdir -p "${STAGING_DIR}/$(dirname "{{ rel_path }}")"
 cp -rL "{{ workspace_name }}/{{ rel_path }}" "${STAGING_DIR}/{{ rel_path }}"
 {% endfor %}
-{% endif %}
+{%- endif %}
 ${RUNTIME} build \
 	--target "${TARGET}" \
 	--build-arg USER_NAME="${USER_NAME}" \

--- a/src/container_magic/templates/run.sh.j2
+++ b/src/container_magic/templates/run.sh.j2
@@ -282,7 +282,7 @@ run_{{ command_name }}() {
 	local _manifest=""
 	if [[ ${#MANIFEST_LINES[@]} -gt 0 ]]; then
 		_manifest=$(mktemp /tmp/cm-manifest-XXXXXX)
-		printf '%s\n' "${MANIFEST_LINES[@]}" > "$_manifest"
+		printf '%s\n' "${MANIFEST_LINES[@]}" >"$_manifest"
 		RUN_ARGS+=("-v" "${_manifest}:/run/cm/mounts:ro,z")
 	fi
 	if [[ ${#REMAINING[@]} -gt 0 ]]; then

--- a/tests/fixtures/configs/alpine_user.yaml
+++ b/tests/fixtures/configs/alpine_user.yaml
@@ -1,0 +1,24 @@
+# Alpine base with user creation (tests alpine-specific adduser/addgroup)
+names:
+  image: test-alpine-app
+  workspace: workspace
+  user: appuser
+
+stages:
+  base:
+    from: alpine:3.19
+    steps:
+      - apk: {add: [python3, py3-pip]}
+      - {create: user}
+      - {become: user,}
+
+  development:
+    from: base
+    steps:
+      - {become: user,}
+
+  production:
+    from: base
+    steps:
+      - {become: user}
+      - copy: workspace

--- a/tests/fixtures/configs/cloud_assets.yaml
+++ b/tests/fixtures/configs/cloud_assets.yaml
@@ -1,0 +1,32 @@
+# AWS credentials feature with downloadable assets
+names:
+  image: test-cloud-tool
+  workspace: workspace
+  user: appuser
+
+assets:
+  - awscli.zip: https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip
+
+runtime:
+  features:
+    - aws_credentials
+
+stages:
+  base:
+    from: python:3.11-slim
+    steps:
+      - apt-get: {install: [unzip, curl]}
+      - {env: {TZ: UTC}}
+      - {create: user}
+      - {become: user,}
+
+  development:
+    from: base
+    steps:
+      - {become: user,}
+
+  production:
+    from: base
+    steps:
+      - {become: user}
+      - copy: workspace

--- a/tests/fixtures/configs/commands_ports.yaml
+++ b/tests/fixtures/configs/commands_ports.yaml
@@ -1,0 +1,54 @@
+# Complex custom commands with ports, env, and mounts
+names:
+  image: test-service-app
+  workspace: workspace
+  user: appuser
+
+runtime:
+  features:
+    - gpu
+  volumes:
+    - /tmp/.cache:/tmp/.cache
+
+stages:
+  base:
+    from: python:3.11-slim
+    steps:
+      - pip: {install: [flask, pytest, gunicorn]}
+      - env:
+          APP_PORT: "8080"
+          CACHE_DIR: /tmp/.cache
+      - {create: user}
+      - {become: user,}
+
+  development:
+    from: base
+    steps:
+      - {become: user,}
+
+  production:
+    from: base
+    steps:
+      - {become: user}
+      - copy: workspace
+
+commands:
+  serve:
+    command: "gunicorn app:create_app()"
+    description: "Run the web server"
+    env:
+      FLASK_ENV: production
+    ports:
+      - "8080:8080"
+
+  test:
+    command: "pytest"
+    description: "Run test suite"
+
+  process:
+    command: "python process.py"
+    description: "Run data processing"
+    mounts:
+      input: ro
+      output: rw
+    ipc: "host"

--- a/tests/fixtures/configs/multistage_builder.yaml
+++ b/tests/fixtures/configs/multistage_builder.yaml
@@ -1,0 +1,30 @@
+# Multi-stage build with builder pattern and cross-stage copy
+names:
+  image: test-compiled-app
+  workspace: workspace
+  user: appuser
+
+stages:
+  builder:
+    from: ubuntu:22.04
+    steps:
+      - apt-get: {install: [build-essential, cmake, git]}
+      - RUN mkdir -p /opt/build && cd /opt/build && cmake --version
+
+  base:
+    from: ubuntu:22.04
+    steps:
+      - apt-get: {install: [libstdc++6]}
+      - COPY --from=builder /opt/build/lib /usr/local/lib
+      - {create: user,}
+
+  development:
+    from: base
+    steps:
+      - {become: user,}
+
+  production:
+    from: base
+    steps:
+      - {become: user}
+      - copy: workspace

--- a/tests/fixtures/configs/network_ipc.yaml
+++ b/tests/fixtures/configs/network_ipc.yaml
@@ -1,0 +1,27 @@
+# Network host mode, IPC sharing, explicit docker backend
+backend: docker
+
+names:
+  image: test-network-app
+  workspace: workspace
+  user: root
+
+runtime:
+  network_mode: host
+  ipc: shareable
+  features:
+    - display
+
+stages:
+  base:
+    from: ubuntu:22.04
+    steps:
+      - apt-get: {install: [libgl1, libx11-6]}
+      - env:
+          DISPLAY_APP: "true"
+
+  development:
+    from: base
+
+  production:
+    from: base

--- a/tests/fixtures/configs/podman_gpu_audio.yaml
+++ b/tests/fixtures/configs/podman_gpu_audio.yaml
@@ -1,0 +1,37 @@
+# Podman backend with GPU and audio features
+backend: podman
+
+names:
+  image: test-media-processor
+  workspace: workspace
+  user: appuser
+
+runtime:
+  privileged: true
+  features:
+    - gpu
+    - audio
+  devices:
+    - /dev/snd
+
+stages:
+  base:
+    from: pytorch/pytorch:2.1.0-cuda11.8-cudnn8-runtime
+    steps:
+      - apt-get: {install: [ffmpeg, libasound2-plugins]}
+      - pip: {install: [torchaudio, soundfile]}
+      - env:
+          MODEL_CACHE: /home/appuser/.cache/models
+      - {create: user}
+      - {become: user,}
+
+  development:
+    from: base
+    steps:
+      - {become: user,}
+
+  production:
+    from: base
+    steps:
+      - {become: user}
+      - copy: workspace

--- a/tests/fixtures/hadolint.yaml
+++ b/tests/fixtures/hadolint.yaml
@@ -1,0 +1,25 @@
+# Hadolint configuration for testing container-magic generated Dockerfiles.
+#
+# These rules are ignored because they apply to user-authored content
+# (run: steps in cm.yaml) that container-magic passes through verbatim,
+# not to container-magic's own generated code.
+ignored:
+  # User chooses base image tags
+  - DL3007  # Using latest is prone to errors
+  # User controls package installation commands
+  - DL3008  # Pin versions in apt-get install
+  - DL3009  # Delete the apt-get lists after installing
+  - DL3015  # Avoid additional packages by specifying --no-install-recommends
+  # User controls pip commands
+  - DL3013  # Pin versions in pip install
+  - DL3042  # Avoid use of cache directory with pip
+  # User creation block uses pipe in an if-condition where failure is handled
+  - DL4006  # Set the SHELL option -o pipefail before RUN with a pipe
+  # apk-specific rules for user content
+  - DL3018  # Pin versions in apk add
+  - DL3019  # Use --no-cache with apk add
+  # User content may use cd in RUN steps
+  - DL3003  # Use WORKDIR to switch to a directory
+  # False positive: nested if-inside-else with variable assignment between
+  # else and if is parsed as "else if" by hadolint's shellcheck
+  - SC1075  # Use 'elif' instead of 'else if'

--- a/tests/integration/test_generation.py
+++ b/tests/integration/test_generation.py
@@ -56,11 +56,19 @@ def validate_yaml(yaml_file: Path) -> bool:
 
 
 def validate_dockerfile(dockerfile: Path) -> bool:
-    """Validate Dockerfile with hadolint (errors only)."""
+    """Validate Dockerfile with hadolint."""
     if not LINTERS["hadolint"]:
         return True
+    hadolint_config = Path(__file__).parent.parent / "fixtures" / "hadolint.yaml"
     result = subprocess.run(
-        ["hadolint", "--failure-threshold", "error", str(dockerfile)],
+        [
+            "hadolint",
+            "--config",
+            str(hadolint_config),
+            "--failure-threshold",
+            "warning",
+            str(dockerfile),
+        ],
         capture_output=True,
     )
     return result.returncode == 0

--- a/tests/integration/test_lint_generated.py
+++ b/tests/integration/test_lint_generated.py
@@ -1,0 +1,259 @@
+"""Lint-check generated Dockerfiles and shell scripts across config variations.
+
+Ensures that container-magic produces output that passes hadolint (Dockerfiles)
+and shellcheck + shfmt (shell scripts) for a wide range of configurations.
+"""
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from container_magic.core.config import ContainerMagicConfig
+from container_magic.generators.build_script import generate_build_script
+from container_magic.generators.dockerfile import generate_dockerfile
+from container_magic.generators.run_script import generate_run_script
+
+FIXTURES_DIR = Path(__file__).parent.parent / "fixtures" / "configs"
+HADOLINT_CONFIG = Path(__file__).parent.parent / "fixtures" / "hadolint.yaml"
+
+# All fixture configs to test
+FIXTURE_CONFIGS = sorted(FIXTURES_DIR.glob("*.yaml"))
+
+# Tool availability
+HAS_HADOLINT = shutil.which("hadolint") is not None
+HAS_SHELLCHECK = shutil.which("shellcheck") is not None
+HAS_SHFMT = shutil.which("shfmt") is not None
+
+
+def _generate_files(config_path: Path, output_dir: Path):
+    """Generate Dockerfile, build.sh, and run.sh from a config file."""
+    config = ContainerMagicConfig.from_yaml(config_path)
+
+    # Create workspace directory (required by generator)
+    workspace_dir = output_dir / config.names.workspace
+    workspace_dir.mkdir(exist_ok=True)
+
+    generate_dockerfile(config, output_dir / "Dockerfile")
+    generate_build_script(config, output_dir)
+    generate_run_script(config, output_dir)
+
+
+@pytest.fixture(
+    params=[p.stem for p in FIXTURE_CONFIGS], ids=[p.stem for p in FIXTURE_CONFIGS]
+)
+def generated_project(request, tmp_path):
+    """Generate a project from each fixture config into a temp directory."""
+    config_name = request.param
+    config_path = FIXTURES_DIR / f"{config_name}.yaml"
+
+    # Copy config to temp dir and generate
+    shutil.copy(config_path, tmp_path / "cm.yaml")
+    _generate_files(tmp_path / "cm.yaml", tmp_path)
+
+    return tmp_path
+
+
+class TestDockerfileLinting:
+    @pytest.mark.skipif(not HAS_HADOLINT, reason="hadolint not installed")
+    def test_hadolint_passes(self, generated_project):
+        """Generated Dockerfile passes hadolint with no warnings (ignoring user-content rules)."""
+        dockerfile = generated_project / "Dockerfile"
+        result = subprocess.run(
+            [
+                "hadolint",
+                "--config",
+                str(HADOLINT_CONFIG),
+                "--failure-threshold",
+                "warning",
+                str(dockerfile),
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, (
+            f"hadolint found issues:\n{result.stdout}\n{result.stderr}"
+        )
+
+
+class TestShellScriptLinting:
+    @pytest.mark.skipif(not HAS_SHELLCHECK, reason="shellcheck not installed")
+    def test_shellcheck_build_sh(self, generated_project):
+        """Generated build.sh passes shellcheck."""
+        result = subprocess.run(
+            ["shellcheck", str(generated_project / "build.sh")],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, (
+            f"shellcheck build.sh:\n{result.stdout}\n{result.stderr}"
+        )
+
+    @pytest.mark.skipif(not HAS_SHELLCHECK, reason="shellcheck not installed")
+    def test_shellcheck_run_sh(self, generated_project):
+        """Generated run.sh passes shellcheck."""
+        result = subprocess.run(
+            ["shellcheck", str(generated_project / "run.sh")],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, (
+            f"shellcheck run.sh:\n{result.stdout}\n{result.stderr}"
+        )
+
+    @pytest.mark.skipif(not HAS_SHFMT, reason="shfmt not installed")
+    def test_shfmt_build_sh(self, generated_project):
+        """Generated build.sh needs no formatting changes."""
+        result = subprocess.run(
+            ["shfmt", "-d", str(generated_project / "build.sh")],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, (
+            f"shfmt build.sh formatting diff:\n{result.stdout}"
+        )
+
+    @pytest.mark.skipif(not HAS_SHFMT, reason="shfmt not installed")
+    def test_shfmt_run_sh(self, generated_project):
+        """Generated run.sh needs no formatting changes."""
+        result = subprocess.run(
+            ["shfmt", "-d", str(generated_project / "run.sh")],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, f"shfmt run.sh formatting diff:\n{result.stdout}"
+
+
+@pytest.fixture(
+    params=["single_symlink", "multiple_symlinks", "nested_symlink"],
+    ids=["single_symlink", "multiple_symlinks", "nested_symlink"],
+)
+def generated_project_with_symlinks(request, tmp_path):
+    """Generate a project with workspace symlinks for linting."""
+    config_dict = {
+        "names": {
+            "image": "test-symlinks",
+            "workspace": "workspace",
+            "user": "appuser",
+        },
+        "stages": {
+            "base": {
+                "from": "python:3-slim",
+                "steps": [{"create": "user"}, {"become": "user"}],
+            },
+            "development": {"from": "base"},
+            "production": {
+                "from": "base",
+                "steps": [{"become": "user"}, {"copy": "workspace"}],
+            },
+        },
+    }
+    config = ContainerMagicConfig(**config_dict)
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    if request.param == "single_symlink":
+        ext = tmp_path / "external_lib"
+        ext.mkdir()
+        (ext / "data.py").write_text("pass")
+        (workspace / "lib").symlink_to(ext)
+    elif request.param == "multiple_symlinks":
+        for name in ["alpha", "beta", "gamma"]:
+            ext = tmp_path / f"ext_{name}"
+            ext.mkdir()
+            (ext / "module.py").write_text("pass")
+            (workspace / name).symlink_to(ext)
+    elif request.param == "nested_symlink":
+        ext = tmp_path / "shared_data"
+        ext.mkdir()
+        (ext / "config.json").write_text("{}")
+        (workspace / "src" / "vendor").mkdir(parents=True)
+        (workspace / "src" / "vendor" / "shared").symlink_to(ext)
+
+    from container_magic.core.symlinks import scan_workspace_symlinks
+
+    symlinks = scan_workspace_symlinks(workspace)
+    generate_dockerfile(config, tmp_path / "Dockerfile", workspace_symlinks=symlinks)
+    generate_build_script(config, tmp_path, workspace_symlinks=symlinks)
+    generate_run_script(config, tmp_path)
+
+    return tmp_path
+
+
+class TestSymlinkLinting:
+    """Lint generated files when workspace symlinks trigger staging code paths."""
+
+    @pytest.mark.skipif(not HAS_HADOLINT, reason="hadolint not installed")
+    def test_hadolint_passes(self, generated_project_with_symlinks):
+        dockerfile = generated_project_with_symlinks / "Dockerfile"
+        result = subprocess.run(
+            [
+                "hadolint",
+                "--config",
+                str(HADOLINT_CONFIG),
+                "--failure-threshold",
+                "warning",
+                str(dockerfile),
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, (
+            f"hadolint found issues:\n{result.stdout}\n{result.stderr}"
+        )
+
+    @pytest.mark.skipif(not HAS_SHELLCHECK, reason="shellcheck not installed")
+    def test_shellcheck_build_sh(self, generated_project_with_symlinks):
+        result = subprocess.run(
+            ["shellcheck", str(generated_project_with_symlinks / "build.sh")],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, (
+            f"shellcheck build.sh:\n{result.stdout}\n{result.stderr}"
+        )
+
+    @pytest.mark.skipif(not HAS_SHFMT, reason="shfmt not installed")
+    def test_shfmt_build_sh(self, generated_project_with_symlinks):
+        result = subprocess.run(
+            ["shfmt", "-d", str(generated_project_with_symlinks / "build.sh")],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, (
+            f"shfmt build.sh formatting diff:\n{result.stdout}"
+        )
+
+    def test_no_consecutive_blank_lines(self, generated_project_with_symlinks):
+        for filename in ["Dockerfile", "build.sh"]:
+            filepath = generated_project_with_symlinks / filename
+            lines = filepath.read_text().splitlines()
+            consecutive = 0
+            for i, line in enumerate(lines, 1):
+                if line.strip() == "":
+                    consecutive += 1
+                    assert consecutive <= 1, (
+                        f"{filename} has consecutive blank lines at line {i}"
+                    )
+                else:
+                    consecutive = 0
+
+
+class TestNoExcessiveBlankLines:
+    def test_no_consecutive_blank_lines(self, generated_project):
+        """No generated file has more than one consecutive blank line."""
+        for filename in ["Dockerfile", "build.sh", "run.sh"]:
+            filepath = generated_project / filename
+            if not filepath.exists():
+                continue
+            lines = filepath.read_text().splitlines()
+            consecutive = 0
+            for i, line in enumerate(lines, 1):
+                if line.strip() == "":
+                    consecutive += 1
+                    assert consecutive <= 1, (
+                        f"{filename} has consecutive blank lines at line {i}"
+                    )
+                else:
+                    consecutive = 0

--- a/tests/unit/test_user_validation.py
+++ b/tests/unit/test_user_validation.py
@@ -455,7 +455,7 @@ def test_alpine_child_stage_uses_adduser():
 
         assert "adduser -D" in content
         assert "useradd" not in content
-        assert "-G ${USER_NAME}" in content
+        assert '-G "${USER_NAME}"' in content
         assert "-G ${USER_GID}" not in content
 
 

--- a/tests/utils/validation.py
+++ b/tests/utils/validation.py
@@ -90,16 +90,18 @@ def validate_yaml(yaml_file: Path) -> ValidationResult:
 
 
 def validate_dockerfile(dockerfile: Path) -> ValidationResult:
-    """Validate Dockerfile with hadolint (errors only)."""
+    """Validate Dockerfile with hadolint."""
     hadolint = shutil.which("hadolint")
     if not hadolint:
         return ValidationResult(True, "hadolint not available (skipped)")
 
-    result = subprocess.run(
-        ["hadolint", "--failure-threshold", "error", str(dockerfile)],
-        capture_output=True,
-        text=True,
-    )
+    hadolint_config = Path(__file__).parent.parent / "fixtures" / "hadolint.yaml"
+    cmd = ["hadolint", "--failure-threshold", "warning"]
+    if hadolint_config.exists():
+        cmd.extend(["--config", str(hadolint_config)])
+    cmd.append(str(dockerfile))
+
+    result = subprocess.run(cmd, capture_output=True, text=True)
 
     if result.returncode != 0:
         return ValidationResult(


### PR DESCRIPTION
Run hadolint, shellcheck, and shfmt against the Dockerfile, build.sh, and run.sh generated from every fixture config. Fix the template issues these linters found: unquoted shell variables in Dockerfile user creation blocks, consecutive blank lines in build.sh with symlinks, and a redirect spacing issue in run.sh.

Adds 7 new fixture configs covering Alpine, Podman, GPU/audio, multi-stage builders, custom commands with ports, cloud assets, and network/IPC modes.