### PR TITLE
feat(pip): auto-create virtual environment for pip steps

### DIFF
--- a/src/container_magic/generators/dockerfile.py
+++ b/src/container_magic/generators/dockerfile.py
@@ -162,6 +162,11 @@ def _resolve_copy_source(args: str, asset_map: Dict[str, str]) -> str:
     return args
 
 
+def _step_is_pip(step: Union[str, Dict[str, Any]]) -> bool:
+    """Check if a raw step is a pip step."""
+    return isinstance(step, dict) and len(step) == 1 and next(iter(step)) == "pip"
+
+
 def process_stage_steps(
     stage: StageConfig,
     stage_name: str,
@@ -172,7 +177,8 @@ def process_stage_steps(
     registry: Dict = None,
     asset_map: Dict[str, str] = None,
     workspace_symlinks: List[tuple] = None,
-) -> List[Dict]:
+    venv_active: bool = False,
+) -> tuple:
     """Process build steps for a stage.
 
     When asset_map is provided, copy sources matching asset filenames are
@@ -182,7 +188,7 @@ def process_stage_steps(
     symlink overlay data for the Dockerfile template.
 
     Returns:
-        ordered_steps list
+        (ordered_steps, venv_active) tuple
     """
     if registry is None:
         registry = load_registry()
@@ -195,7 +201,7 @@ def process_stage_steps(
     is_default_production = False
     if stage.steps is None:
         if ":" in stage.frm or "/" in stage.frm:
-            return []
+            return [], venv_active
         else:
             steps: List[Union[str, Dict[str, Any]]] = []
             if stage_name == "production":
@@ -230,6 +236,14 @@ def process_stage_steps(
     ordered_steps = []
 
     for step in steps:
+        if _step_is_pip(step) and not venv_active:
+            is_root = current_user is None
+            venv_step = {"type": "venv_setup", "is_root": is_root}
+            if not is_root:
+                venv_step["restore_user"] = current_user
+            ordered_steps.append(venv_step)
+            venv_active = True
+
         parsed = parse_step(step, registry)
 
         step_type = parsed["type"]
@@ -294,7 +308,7 @@ def process_stage_steps(
         elif step_type == "passthrough":
             ordered_steps.append({"type": "custom", "command": parsed["command"]})
 
-    return ordered_steps
+    return ordered_steps, venv_active
 
 
 def generate_dockerfile(
@@ -349,6 +363,7 @@ def generate_dockerfile(
     user_home = f"/home/{user_name}" if has_user else "/root"
 
     stages_data = []
+    venv_state: Dict[str, bool] = {}
     for stage_name, stage_config in stages.items():
         base_image = stage_config.frm
         resolved_image = resolve_base_image(base_image, stages)
@@ -358,7 +373,13 @@ def generate_dockerfile(
         shell = stage_config.shell or detect_shell(resolved_image)
         user_creation_style = detect_user_creation_style(resolved_image)
 
-        ordered_steps = process_stage_steps(
+        from_is_image = ":" in base_image or "/" in base_image
+        if from_is_image:
+            inherited_venv = False
+        else:
+            inherited_venv = venv_state.get(base_image, False)
+
+        ordered_steps, venv_active = process_stage_steps(
             stage_config,
             stage_name,
             project_dir,
@@ -368,12 +389,13 @@ def generate_dockerfile(
             registry,
             asset_map,
             workspace_symlinks,
+            venv_active=inherited_venv,
         )
+        venv_state[stage_name] = venv_active
 
         ordered_steps = _merge_consecutive_env_steps(ordered_steps)
 
         needs_user_args = _stage_needs_user_args(ordered_steps)
-        from_is_image = ":" in base_image or "/" in base_image
 
         stages_data.append(
             {

--- a/src/container_magic/templates/Dockerfile.j2
+++ b/src/container_magic/templates/Dockerfile.j2
@@ -122,6 +122,16 @@ ENV {% for key, value in step.vars.items() %}{% if not loop.first %}    {% endif
 {% endif %}{% endfor %}
 
 {% endif %}
+{% elif step.type == "venv_setup" %}
+{% if not step.is_root %}
+USER root
+{% endif %}
+RUN test -f /opt/venv/pyvenv.cfg || python3 -m venv --system-site-packages /opt/venv
+ENV VIRTUAL_ENV=/opt/venv
+ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
+{% if not step.is_root %}
+USER {{ step.restore_user }}
+{% endif %}
 {% elif step.type == "custom" %}
 {% if step.command.startswith('ADD ') or step.command.startswith('ARG ') or step.command.startswith('CMD ') or step.command.startswith('COPY ') or step.command.startswith('ENTRYPOINT ') or step.command.startswith('ENV ') or step.command.startswith('EXPOSE ') or step.command.startswith('FROM ') or step.command.startswith('HEALTHCHECK ') or step.command.startswith('LABEL ') or step.command.startswith('RUN ') or step.command.startswith('SHELL ') or step.command.startswith('STOPSIGNAL ') or step.command.startswith('USER ') or step.command.startswith('VOLUME ') or step.command.startswith('WORKDIR ') %}
 {{ step.command }}

--- a/tests/fixtures/configs/pip_venv.yaml
+++ b/tests/fixtures/configs/pip_venv.yaml
@@ -1,0 +1,26 @@
+# Config with pip steps to validate venv injection passes linters
+names:
+  image: test-pip-venv
+  workspace: workspace
+  user: appuser
+
+stages:
+  base:
+    from: python:3.11-slim
+    steps:
+      - apt-get: {install: [curl]}
+      - pip: {install: [requests, flask]}
+      - {create: user}
+      - {become: user,}
+
+  development:
+    from: base
+    steps:
+      - {become: user}
+      - pip: {install: [pytest]}
+
+  production:
+    from: base
+    steps:
+      - {become: user}
+      - copy: workspace

--- a/tests/unit/test_pip_venv.py
+++ b/tests/unit/test_pip_venv.py
@@ -1,0 +1,216 @@
+"""Tests for automatic venv creation on pip steps."""
+
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from container_magic.core.config import ContainerMagicConfig
+from container_magic.generators.dockerfile import generate_dockerfile
+
+
+def _generate(config_dict):
+    """Generate a Dockerfile from a config dict and return its content."""
+    config = ContainerMagicConfig(**config_dict)
+    with TemporaryDirectory() as tmpdir:
+        output_path = Path(tmpdir) / "Dockerfile"
+        generate_dockerfile(config, output_path)
+        return output_path.read_text()
+
+
+def _base_config(**overrides):
+    """Minimal config with overrides applied to the base stage."""
+    config = {
+        "names": {"image": "test", "workspace": "workspace", "user": "root"},
+        "stages": {
+            "base": {"from": "python:3-slim", **overrides},
+            "development": {"from": "base", "steps": []},
+            "production": {"from": "base", "steps": []},
+        },
+    }
+    return config
+
+
+class TestVenvCreation:
+    def test_pip_as_root_creates_venv(self):
+        """First pip step as root injects venv setup."""
+        config = _base_config(steps=[{"pip": {"install": ["numpy"]}}])
+        content = _generate(config)
+        assert "python3 -m venv --system-site-packages /opt/venv" in content
+        assert "ENV VIRTUAL_ENV=/opt/venv" in content
+        assert 'ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"' in content
+        # Should NOT have USER switching (already root)
+        lines = content.splitlines()
+        venv_idx = next(
+            i for i, line in enumerate(lines) if "venv" in line and "RUN" in line
+        )
+        # No USER root before venv line
+        assert "USER root" not in lines[venv_idx - 1]
+
+    def test_pip_after_become_user_switches_to_root(self):
+        """Pip step after become: user injects USER root / USER restore."""
+        config = {
+            "names": {"image": "test", "workspace": "workspace", "user": "appuser"},
+            "stages": {
+                "base": {
+                    "from": "python:3-slim",
+                    "steps": [
+                        {"create": "user"},
+                        {"become": "user"},
+                        {"pip": {"install": ["flask"]}},
+                    ],
+                },
+                "development": {"from": "base"},
+                "production": {"from": "base"},
+            },
+        }
+        content = _generate(config)
+        lines = content.splitlines()
+        # Find venv creation
+        venv_idx = next(
+            i for i, line in enumerate(lines) if "venv" in line and "RUN" in line
+        )
+        # USER root before venv creation
+        preceding = [line.strip() for line in lines[:venv_idx] if line.strip()]
+        assert preceding[-1] == "USER root"
+        # USER restore after ENV PATH
+        path_idx = next(
+            i
+            for i, line in enumerate(lines)
+            if "VIRTUAL_ENV" in line and "PATH" in line
+        )
+        restore_lines = [line.strip() for line in lines[path_idx + 1 :] if line.strip()]
+        assert restore_lines[0].startswith("USER ")
+        assert restore_lines[0] != "USER root"
+
+    def test_child_stage_inherits_venv(self):
+        """Pip step in child stage skips venv setup if parent already created one."""
+        config = {
+            "names": {"image": "test", "workspace": "workspace", "user": "appuser"},
+            "stages": {
+                "base": {
+                    "from": "python:3-slim",
+                    "steps": [
+                        {"pip": {"install": ["numpy"]}},
+                        {"create": "user"},
+                    ],
+                },
+                "development": {
+                    "from": "base",
+                    "steps": [
+                        {"become": "user"},
+                        {"pip": {"install": ["pytest"]}},
+                    ],
+                },
+                "production": {"from": "base"},
+            },
+        }
+        content = _generate(config)
+        assert content.count("python3 -m venv") == 1
+
+    def test_child_stage_without_parent_venv_creates_own(self):
+        """Pip step in child stage creates venv if parent had no pip steps."""
+        config = {
+            "names": {"image": "test", "workspace": "workspace", "user": "appuser"},
+            "stages": {
+                "base": {
+                    "from": "python:3-slim",
+                    "steps": [{"create": "user"}],
+                },
+                "development": {
+                    "from": "base",
+                    "steps": [
+                        {"become": "user"},
+                        {"pip": {"install": ["pytest"]}},
+                    ],
+                },
+                "production": {"from": "base"},
+            },
+        }
+        content = _generate(config)
+        assert "python3 -m venv" in content
+        assert "USER root" in content
+
+    def test_no_pip_steps_no_venv(self):
+        """No venv setup when no pip steps exist."""
+        config = _base_config(steps=[{"run": "echo hello"}])
+        content = _generate(config)
+        assert "venv" not in content
+        assert "VIRTUAL_ENV" not in content
+
+    def test_multiple_pip_steps_single_venv(self):
+        """Multiple pip steps in same stage only create venv once."""
+        config = _base_config(
+            steps=[
+                {"pip": {"install": ["numpy"]}},
+                {"pip": {"install": ["flask"]}},
+            ]
+        )
+        content = _generate(config)
+        assert content.count("python3 -m venv") == 1
+        assert content.count("ENV VIRTUAL_ENV=") == 1
+
+    def test_venv_env_ordering(self):
+        """VIRTUAL_ENV must be set before PATH references it."""
+        config = _base_config(steps=[{"pip": {"install": ["numpy"]}}])
+        content = _generate(config)
+        lines = content.splitlines()
+        venv_env_idx = next(
+            i for i, line in enumerate(lines) if "VIRTUAL_ENV=/opt/venv" in line
+        )
+        path_env_idx = next(
+            i for i, line in enumerate(lines) if "VIRTUAL_ENV}/bin" in line
+        )
+        assert venv_env_idx < path_env_idx
+
+    def test_venv_guard_prevents_clobbering(self):
+        """Venv creation uses test -f guard for idempotency."""
+        config = _base_config(steps=[{"pip": {"install": ["numpy"]}}])
+        content = _generate(config)
+        assert "test -f /opt/venv/pyvenv.cfg" in content
+
+    def test_pip_single_package_string(self):
+        """Pip step with single package as string (not list) also creates venv."""
+        config = _base_config(steps=[{"pip": {"install": "requests"}}])
+        content = _generate(config)
+        assert "python3 -m venv --system-site-packages /opt/venv" in content
+        assert "requests" in content
+
+    def test_become_without_create_user(self):
+        """Pip after become to a pre-existing user (no create step) still switches to root."""
+        config = {
+            "names": {"image": "test", "workspace": "workspace", "user": "root"},
+            "stages": {
+                "base": {
+                    "from": "python:3-slim",
+                    "steps": [
+                        {"become": "www-data"},
+                        {"pip": {"install": ["flask"]}},
+                    ],
+                },
+                "development": {"from": "base", "steps": []},
+                "production": {"from": "base", "steps": []},
+            },
+        }
+        content = _generate(config)
+        assert "USER root" in content
+        assert "USER www-data" in content
+        assert "python3 -m venv" in content
+
+    def test_stage_from_external_image_resets_venv(self):
+        """Stage from external image (not parent stage) starts fresh."""
+        config = {
+            "names": {"image": "test", "workspace": "workspace", "user": "root"},
+            "stages": {
+                "builder": {
+                    "from": "python:3-slim",
+                    "steps": [{"pip": {"install": ["build"]}}],
+                },
+                "base": {
+                    "from": "ubuntu:24.04",
+                    "steps": [{"pip": {"install": ["requests"]}}],
+                },
+                "development": {"from": "base"},
+                "production": {"from": "base"},
+            },
+        }
+        content = _generate(config)
+        assert content.count("python3 -m venv") == 2


### PR DESCRIPTION
Automatically create a virtual environment at /opt/venv before the first pip step in each stage, handling PEP 668 images (Ubuntu 24.04+, Debian 12+) without any config changes. Tracks venv state across stage inheritance so child stages skip the setup. Handles root and non-root user contexts correctly.