### PR TITLE
docs: rewrite README for implicit user handling and clearer value proposition

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,26 +3,23 @@
 
   # container-magic
 
-  **Rapidly create containerised development environments**
-
-  Configure once in YAML, use anywhere with Docker or Podman
+  **Turn a YAML file into a Dockerfile, build script, and run script that work with plain Docker or Podman - no tools to install, no dependencies to manage. One config gives you a live-mounted development environment and a production-ready image.**
 
   [![PyPI version](https://img.shields.io/pypi/v/container-magic.svg)](https://pypi.org/project/container-magic/)
   [![Python versions](https://img.shields.io/pypi/pyversions/container-magic.svg)](https://pypi.org/project/container-magic/)
   [![CI Status](https://github.com/markhedleyjones/container-magic/actions/workflows/ci.yml/badge.svg)](https://github.com/markhedleyjones/container-magic/actions/workflows/ci.yml)
   [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-  [![Code style: ruff](https://img.shields.io/badge/code%20style-ruff-000000.svg)](https://github.com/astral-sh/ruff)
 </div>
 
-## What It Does
+## How It Works
 
-Container-magic takes a single YAML configuration file and generates:
-1. A **Dockerfile** with multi-stage builds
-2. Standalone **build.sh** and **run.sh** scripts for production
+You write a `cm.yaml`. Container-magic generates a Dockerfile, `build.sh`, and `run.sh` from it. You commit those generated files to your repository.
 
-For development, `cm build` and `cm run` read the config directly and handle workspace mounting, user mapping, and feature flags automatically.
+Your colleagues run `./build.sh` and `./run.sh` with plain Docker or Podman. They never need to install container-magic.
 
-The generated files are committed to your repository, so anyone can use your project with just `docker` or `podman` - no need to install container-magic.
+When you change the config, you regenerate and commit. The generated files are always the source of truth for anyone without container-magic installed.
+
+For your own development, `cm build` and `cm run` read the config directly and handle workspace mounting, user identity mapping, and runtime features automatically.
 
 ## Quick Start
 
@@ -54,27 +51,33 @@ stages:
           install:
             - numpy
             - pandas
-      - create: user
-      - become: user
 
   development:
     from: base
 
   production:
     from: base
-    steps:
-      - copy: workspace
+```
+
+Your colleagues build and run the production image without container-magic:
+
+```bash
+./build.sh
+./run.sh python workspace/train.py
 ```
 
 ## Key Features
 
-* **YAML configuration** - single source of truth for your container setup
+* **Zero-dependency output** - generated Dockerfile, build.sh, and run.sh work with plain Docker or Podman
+* **Development and production from one config** - live-mounted workspace in dev, baked-in code in prod
+* **Automatic user handling** - host user identity in dev, dedicated user in prod, no manual setup
+* **GPU, display, and audio** - NVIDIA GPU passthrough, X11/Wayland forwarding, PulseAudio/PipeWire
+* **Custom commands** - define once, use in both dev and prod with port publishing and environment variables
+* **Multi-stage builds** - share steps between stages, automatic virtual environments for pip
 * **Transparent execution** - run commands from anywhere in your repo with automatic path translation
-* **Custom commands** - define commands once, use in both dev and prod
-* **Smart features** - GPU, display (X11/Wayland), and audio support
-* **Multi-stage builds** - separate base, development, and production stages
-* **Cached assets** - download models/datasets once, reuse across builds
-* **Standalone scripts** - production needs only docker/podman
+* **AWS credential forwarding** - mount host AWS config into the container
+* **Cached assets** - download models and datasets once, reuse across builds
+* **Docker and Podman** - works with either runtime, auto-detected
 
 ## Documentation
 
@@ -84,11 +87,11 @@ Full documentation is available at **[markhedleyjones.com/container-magic](https
 |------|----------|
 | [Getting Started](https://markhedleyjones.com/container-magic/getting-started/) | Installation, first project, workflow |
 | [Configuration](https://markhedleyjones.com/container-magic/configuration/) | Full YAML reference - names, runtime, stages, commands |
-| [Build Steps](https://markhedleyjones.com/container-magic/build-steps/) | Built-in steps, package managers, custom commands, layer caching |
+| [Build Steps](https://markhedleyjones.com/container-magic/build-steps/) | Package managers, custom commands, layer caching |
 | [Cached Assets](https://markhedleyjones.com/container-magic/cached-assets/) | Asset downloading, caching, and cache management |
 | [User Handling](https://markhedleyjones.com/container-magic/user-handling/) | Dev vs prod users, copy ownership, permissions |
 | [Troubleshooting](https://markhedleyjones.com/container-magic/troubleshooting/) | Common issues and solutions |
 
 ## Contributing
 
-Container-magic is in early development. Contributions and feedback welcome!
+Contributions and feedback welcome! Open an issue or pull request on GitHub.


### PR DESCRIPTION
Replace the tagline with a clearer value proposition that lands the zero-dependency
differentiator upfront. Update the example config for implicit user handling (no
explicit create/become). Add a colleague-facing example showing build.sh and run.sh
usage. Expand and reorder the feature list by importance.