### PR TITLE
feat(volumes): add shorthand for named data mounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Build and run the production image:
 * **Custom commands** - define once, use in both dev and prod with port publishing and environment variables
 * **Multi-stage builds** - share steps between stages, automatic virtual environments for pip
 * **Transparent execution** - run commands from anywhere in your repo with automatic path translation
+* **Data volumes** - shorthand for sibling folders (`outputs`, `cache`) that persist across runs without entering the image
 * **AWS credential forwarding** - mount host AWS config into the container
 * **Cached assets** - download models and datasets once, reuse across builds
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -79,6 +79,7 @@ runtime:
     - audio            # PulseAudio/PipeWire
     - aws_credentials  # AWS credential forwarding
   volumes:
+    - outputs                           # shorthand: ./outputs:/data/outputs
     - /host/path:/container/path        # bind mount
     - /host/path:/container/path:ro     # read-only bind mount
     - ~/.config/tool:~/.config/tool     # tilde expands to home directories
@@ -112,6 +113,32 @@ runtime:
 ```
 
 In the generated `run.sh`, `~` and `$HOME` on your side are rendered as `$HOME` for shell expansion at runtime. The container side is expanded to a literal path at generation time. Volumes using `$WORKSPACE` are not included in `run.sh` because the workspace is baked into the production image - a warning is printed during `cm update` if this applies.
+
+#### Shorthand
+
+A bare name (no colon) is shorthand for a data folder that lives as a sibling
+of the project and is mounted under `/data/` inside the container. For example:
+
+```yaml
+runtime:
+  volumes:
+    - outputs
+    - cache
+```
+
+expands to:
+
+- `./outputs:/data/outputs`
+- `./cache:/data/cache`
+
+The host folder is created if missing - in development relative to the project
+root, in production relative to the directory containing `run.sh`. Names must
+match `[a-zA-Z0-9_-]+`; anything else needs the full `host:container` form.
+
+Shorthand exists so bulk data (model outputs, caches, datasets) stays out of
+the workspace and out of the built image. Operators deploying the image
+elsewhere (Kubernetes, AWS Batch, etc.) can override by editing the generated
+mounts - the container-side path is always `/data/<name>`.
 
 ### Per-Stage Runtime
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -140,6 +140,46 @@ the workspace and out of the built image. Operators deploying the image
 elsewhere (Kubernetes, AWS Batch, etc.) can override by editing the generated
 mounts - the container-side path is always `/data/<name>`.
 
+#### Data shared across multiple projects
+
+Shorthand assumes the data folder is a sibling of the project. When data lives
+elsewhere - a parent directory shared by several containers, an absolute path,
+or somewhere under `$HOME` - use the full `host:container` form. Any path
+Docker accepts works:
+
+```yaml
+runtime:
+  volumes:
+    # Parent directory shared by multiple container-magic projects
+    - ../shared-data:/data/shared
+
+    # Absolute path (most predictable for production)
+    - /srv/pipeline/outputs:/data/outputs
+
+    # Path under the host user's home (rendered as $HOME in run.sh)
+    - ~/datasets:/data/datasets:ro
+```
+
+For multi-container setups where several projects read and write the same
+folder, the typical pattern is a parent directory:
+
+```
+pipeline/
+  shared-data/          <- written by scraper, read by trainer
+  scraper/
+    cm.yaml             <- volumes: - ../shared-data:/data/shared
+    run.sh
+  trainer/
+    cm.yaml             <- volumes: - ../shared-data:/data/shared:ro
+    run.sh
+```
+
+Relative paths in the full form are resolved by Docker relative to the CWD
+where `cm run` or `run.sh` is invoked. `cm run` changes into the project
+directory first, so `../shared-data` is always resolved relative to the
+project. For `run.sh`, invoke it from the project directory or use an
+absolute path to avoid surprises.
+
 ### Per-Stage Runtime
 
 Stages can override or extend the global runtime configuration by adding a `runtime` block within the stage definition:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -116,69 +116,60 @@ In the generated `run.sh`, `~` and `$HOME` on your side are rendered as `$HOME` 
 
 #### Shorthand
 
-A bare name (no colon) is shorthand for a data folder that lives as a sibling
-of the project and is mounted under `/data/` inside the container. For example:
+A volume with no colon is shorthand. The container-side path is picked
+automatically as `/data/<basename>`, where `<basename>` is the last path
+segment of the host side. A colon is only needed when you want a different
+container-side name.
 
 ```yaml
 runtime:
   volumes:
-    - outputs
-    - cache
+    - outputs                      # ./outputs           -> /data/outputs
+    - cache                        # ./cache             -> /data/cache
+    - ../shared                    # ../shared           -> /data/shared
+    - /srv/pipeline/outputs        # /srv/pipeline/...   -> /data/outputs
+    - ~/datasets                   # ~/datasets          -> /data/datasets
 ```
 
-expands to:
+Host-side path handling depends on whether the path is relative:
 
-- `./outputs:/data/outputs`
-- `./cache:/data/cache`
+- **Relative paths** (bare names, `./x`, `../x`) are anchored to the project
+  directory in development and to the directory containing `run.sh` in
+  production. The host folder is created if missing.
+- **Absolute paths**, `~/x`, and `$HOME/x` are self-sufficient and are
+  passed through as-is. The host folder must already exist; container-magic
+  will not create folders outside the project root.
 
-The host folder is created if missing - in development relative to the project
-root, in production relative to the directory containing `run.sh`. Names must
-match `[a-zA-Z0-9_-]+`; anything else needs the full `host:container` form.
+The basename must match `[a-zA-Z0-9_-]+`. Paths that don't yield a valid
+basename (`..`, `/`, empty strings, names with dots or spaces) are rejected
+at config-parse time. Two volumes that resolve to the same container path
+are also rejected as a collision - no silent clobbering.
 
 Shorthand exists so bulk data (model outputs, caches, datasets) stays out of
-the workspace and out of the built image. Operators deploying the image
-elsewhere (Kubernetes, AWS Batch, etc.) can override by editing the generated
-mounts - the container-side path is always `/data/<name>`.
+the workspace and out of the built image. Operators deploying elsewhere can
+read the container-side path directly from cm.yaml - it's always
+`/data/<basename>`.
 
-#### Data shared across multiple projects
+#### Multi-container setups
 
-Shorthand assumes the data folder is a sibling of the project. When data lives
-elsewhere - a parent directory shared by several containers, an absolute path,
-or somewhere under `$HOME` - use the full `host:container` form. Any path
-Docker accepts works:
-
-```yaml
-runtime:
-  volumes:
-    # Parent directory shared by multiple container-magic projects
-    - ../shared-data:/data/shared
-
-    # Absolute path (most predictable for production)
-    - /srv/pipeline/outputs:/data/outputs
-
-    # Path under the host user's home (rendered as $HOME in run.sh)
-    - ~/datasets:/data/datasets:ro
-```
-
-For multi-container setups where several projects read and write the same
-folder, the typical pattern is a parent directory:
+When several container-magic projects share the same data folder, put the
+folder in a parent directory and reference it with `../`:
 
 ```
 pipeline/
-  shared-data/          <- written by scraper, read by trainer
+  shared/               <- written by scraper, read by trainer
   scraper/
-    cm.yaml             <- volumes: - ../shared-data:/data/shared
+    cm.yaml             <- volumes: - ../shared
     run.sh
   trainer/
-    cm.yaml             <- volumes: - ../shared-data:/data/shared:ro
-    run.sh
+    cm.yaml             <- volumes: - ../shared:/data/shared:ro
+    run.sh              #  (full form used here for :ro)
 ```
 
-Relative paths in the full form are resolved by Docker relative to the CWD
-where `cm run` or `run.sh` is invoked. `cm run` changes into the project
-directory first, so `../shared-data` is always resolved relative to the
-project. For `run.sh`, invoke it from the project directory or use an
-absolute path to avoid surprises.
+Both projects see the shared folder at `/data/shared` inside their
+respective containers. The scraper can write; the trainer reads only. Use
+the full `host:container[:options]` form whenever you need `:ro` or other
+mount options.
 
 ### Per-Stage Runtime
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -59,8 +59,21 @@ runtime:
 
 Bare names are shorthand: the host folder is a sibling of `run.sh`, the
 container path is `/data/<name>`. The folder is created if missing. This
-works identically in development (`cm run`) and production (`run.sh`). See
-[Volumes](configuration.md#volumes) for the full syntax.
+works identically in development (`cm run`) and production (`run.sh`).
+
+For data that lives elsewhere - a parent directory shared by several
+containers, an absolute path, or somewhere under `$HOME` - use the full
+`host:container` form:
+
+```yaml
+runtime:
+  volumes:
+    - ../shared-data:/data/shared     # parent dir, shared across projects
+    - /srv/pipeline/outputs:/data/out  # absolute path
+    - ~/datasets:/data/datasets:ro    # read-only mount from home
+```
+
+See [Volumes](configuration.md#volumes) for the full syntax.
 
 ## Workflow
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -31,6 +31,37 @@ cm run bash -c "echo Hello from container"
 cm run           # starts an interactive shell
 ```
 
+## Project Layout
+
+```
+my-project/
+  cm.yaml           <- config you edit
+  Dockerfile        <- generated
+  build.sh          <- generated
+  run.sh            <- generated
+  workspace/        <- your code and assets (baked into the image)
+  outputs/          <- data produced at runtime (mounted, NOT in image)
+  cache/            <- data produced at runtime (mounted, NOT in image)
+```
+
+Anything under `workspace/` is copied into the production image at build time,
+so keep it to code, configuration, and small assets. Anything you want to
+persist across runs but keep out of the image - model outputs, logs,
+downloaded datasets, caches - goes in a sibling folder and is declared under
+`runtime.volumes:`.
+
+```yaml
+runtime:
+  volumes:
+    - outputs    # shorthand for ./outputs:/data/outputs
+    - cache      # shorthand for ./cache:/data/cache
+```
+
+Bare names are shorthand: the host folder is a sibling of `run.sh`, the
+container path is `/data/<name>`. The folder is created if missing. This
+works identically in development (`cm run`) and production (`run.sh`). See
+[Volumes](configuration.md#volumes) for the full syntax.
+
 ## Workflow
 
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -53,25 +53,19 @@ downloaded datasets, caches - goes in a sibling folder and is declared under
 ```yaml
 runtime:
   volumes:
-    - outputs    # shorthand for ./outputs:/data/outputs
-    - cache      # shorthand for ./cache:/data/cache
+    - outputs                  # sibling folder -> /data/outputs
+    - cache                    # sibling folder -> /data/cache
+    - ../shared                # parent dir, shared with other projects
+    - /srv/pipeline/datasets   # absolute path
+    - ~/models                 # path under your home
 ```
 
-Bare names are shorthand: the host folder is a sibling of `run.sh`, the
-container path is `/data/<name>`. The folder is created if missing. This
-works identically in development (`cm run`) and production (`run.sh`).
-
-For data that lives elsewhere - a parent directory shared by several
-containers, an absolute path, or somewhere under `$HOME` - use the full
-`host:container` form:
-
-```yaml
-runtime:
-  volumes:
-    - ../shared-data:/data/shared     # parent dir, shared across projects
-    - /srv/pipeline/outputs:/data/out  # absolute path
-    - ~/datasets:/data/datasets:ro    # read-only mount from home
-```
+Any volume without a colon is shorthand: the container-side path is picked as
+`/data/<basename>` from the host path. Relative paths (bare names, `./`, `../`)
+are created if missing and anchored to the project directory in development or
+to the directory containing `run.sh` in production. Absolute and `~` paths are
+passed through as-is and must already exist. Use the full `host:container` form
+only when you want a different container name or need mount options like `:ro`.
 
 See [Volumes](configuration.md#volumes) for the full syntax.
 

--- a/src/container_magic/core/config.py
+++ b/src/container_magic/core/config.py
@@ -190,23 +190,33 @@ class RuntimeConfig(BaseModel):
     @field_validator("volumes")
     @classmethod
     def validate_volume_format(cls, v):
-        """Validate volume strings: either shorthand names or host:container."""
+        """Validate volume strings and reject colliding container paths."""
         from container_magic.core.volumes import (
+            container_path_of,
             is_shorthand_volume,
-            validate_shorthand_name,
+            parse_shorthand,
         )
 
+        seen: dict = {}
         for volume in v:
             if is_shorthand_volume(volume):
-                validate_shorthand_name(volume)
-                continue
-            parts = volume.split(":")
-            if len(parts) < 2 or not parts[0] or not parts[1]:
+                parse_shorthand(volume)
+            else:
+                parts = volume.split(":")
+                if len(parts) < 2 or not parts[0] or not parts[1]:
+                    raise ValueError(
+                        f"Invalid volume format '{volume}': must be "
+                        f"host:container[:options] or a shorthand host path "
+                        f"(e.g. 'outputs' or '../shared')"
+                    )
+
+            cpath = container_path_of(volume)
+            if cpath in seen:
                 raise ValueError(
-                    f"Invalid volume format '{volume}': must be "
-                    f"host:container[:options] or a bare name "
-                    f"(e.g. 'outputs' for ./outputs:/data/outputs)"
+                    f"Volume collision: '{volume}' and '{seen[cpath]}' both "
+                    f"mount at container path '{cpath}'"
                 )
+            seen[cpath] = volume
         return v
 
     @field_validator("devices")

--- a/src/container_magic/core/config.py
+++ b/src/container_magic/core/config.py
@@ -190,12 +190,22 @@ class RuntimeConfig(BaseModel):
     @field_validator("volumes")
     @classmethod
     def validate_volume_format(cls, v):
-        """Validate volume strings have at least host:container."""
+        """Validate volume strings: either shorthand names or host:container."""
+        from container_magic.core.volumes import (
+            is_shorthand_volume,
+            validate_shorthand_name,
+        )
+
         for volume in v:
+            if is_shorthand_volume(volume):
+                validate_shorthand_name(volume)
+                continue
             parts = volume.split(":")
             if len(parts) < 2 or not parts[0] or not parts[1]:
                 raise ValueError(
-                    f"Invalid volume format '{volume}': must be host:container[:options]"
+                    f"Invalid volume format '{volume}': must be "
+                    f"host:container[:options] or a bare name "
+                    f"(e.g. 'outputs' for ./outputs:/data/outputs)"
                 )
         return v
 

--- a/src/container_magic/core/runner.py
+++ b/src/container_magic/core/runner.py
@@ -29,7 +29,7 @@ from container_magic.core.volumes import (
     expand_mount_path,
     expand_volumes_for_run,
     label_volumes,
-    shorthand_names,
+    shorthand_anchored_paths,
 )
 
 
@@ -377,9 +377,9 @@ def run_container(
     for env_file in collect_env_files(project_dir):
         run_args.extend(["--env-file", str(env_file)])
 
-    # Create host folders for shorthand volumes before docker mounts them
-    for name in shorthand_names(effective_rt.volumes):
-        (project_dir / name).mkdir(parents=True, exist_ok=True)
+    # Create host folders for relative-path shorthand volumes
+    for host_path in shorthand_anchored_paths(effective_rt.volumes):
+        (project_dir / host_path).mkdir(parents=True, exist_ok=True)
 
     # Additional volumes (with variable expansion)
     volume_context = VolumeContext(

--- a/src/container_magic/core/runner.py
+++ b/src/container_magic/core/runner.py
@@ -29,6 +29,7 @@ from container_magic.core.volumes import (
     expand_mount_path,
     expand_volumes_for_run,
     label_volumes,
+    shorthand_names,
 )
 
 
@@ -376,12 +377,17 @@ def run_container(
     for env_file in collect_env_files(project_dir):
         run_args.extend(["--env-file", str(env_file)])
 
+    # Create host folders for shorthand volumes before docker mounts them
+    for name in shorthand_names(effective_rt.volumes):
+        (project_dir / name).mkdir(parents=True, exist_ok=True)
+
     # Additional volumes (with variable expansion)
     volume_context = VolumeContext(
         user_home=os.path.expanduser("~"),
         container_home=container_home,
         workspace_user=str(project_dir / config.names.workspace),
         workspace_container=f"{container_home}/{config.names.workspace}",
+        project_dir=str(project_dir),
     )
     expanded_volumes = expand_volumes_for_run(effective_rt.volumes, volume_context)
     labelled_volumes = label_volumes(expanded_volumes)

--- a/src/container_magic/core/volumes.py
+++ b/src/container_magic/core/volumes.py
@@ -1,31 +1,82 @@
 """Volume string helpers for SELinux labelling and variable expansion."""
 
+import os
 import re
 import sys
 from dataclasses import dataclass
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 SHORTHAND_CONTAINER_PREFIX = "/data"
 _SHORTHAND_NAME_PATTERN = re.compile(r"^[a-zA-Z0-9_-]+$")
 
 
 def is_shorthand_volume(volume: str) -> bool:
-    """Return True if the volume string is shorthand (a bare name, no colon)."""
+    """Return True if the volume string has no colon (shorthand form)."""
     return ":" not in volume
 
 
-def validate_shorthand_name(name: str) -> None:
-    """Raise ValueError if a shorthand volume name is malformed."""
+def validate_shorthand_basename(name: str) -> None:
+    """Raise ValueError if a shorthand basename is not a valid identifier."""
     if not _SHORTHAND_NAME_PATTERN.match(name):
         raise ValueError(
-            f"Invalid shorthand volume '{name}': bare names must match "
-            f"[a-zA-Z0-9_-]+. Use 'host:container' for anything else."
+            f"Invalid shorthand volume basename '{name}': must match "
+            f"[a-zA-Z0-9_-]+. Use 'host:container' for custom container paths."
         )
 
 
-def shorthand_names(volumes: List[str]) -> List[str]:
-    """Return the bare names of shorthand entries from a volumes list."""
-    return [v for v in volumes if is_shorthand_volume(v)]
+def parse_shorthand(host_path: str) -> Tuple[str, str]:
+    """Parse a shorthand host path into (cleaned_host, basename).
+
+    Strips trailing slashes. Raises ValueError if the basename is not a valid
+    identifier or the host path is empty.
+    """
+    cleaned = host_path.rstrip("/")
+    if not cleaned:
+        raise ValueError(f"Invalid shorthand volume '{host_path}': host path is empty")
+    basename = cleaned.rsplit("/", 1)[-1]
+    validate_shorthand_basename(basename)
+    return cleaned, basename
+
+
+def _host_needs_anchor(path: str) -> bool:
+    """Return True if a host path needs project / run.sh-dir anchoring.
+
+    Relative paths (bare names, './x', '../x') need anchoring. Absolute paths,
+    '~' and '$' prefixes are self-sufficient and are left alone.
+    """
+    if not path:
+        return False
+    return not (path.startswith(("/", "~", "$")))
+
+
+def shorthand_anchored_paths(volumes: List[str]) -> List[str]:
+    """Return cleaned host paths for shorthand entries that need mkdir.
+
+    Only relative host paths (bare names and './' / '../' prefixes) are
+    returned. Absolute and '~' / '$' prefixed paths are the caller's
+    responsibility.
+    """
+    result = []
+    for v in volumes:
+        if not is_shorthand_volume(v):
+            continue
+        host, _ = parse_shorthand(v)
+        if _host_needs_anchor(host):
+            result.append(host)
+    return result
+
+
+def shorthand_container_path(volume: str) -> str:
+    """Return the container-side path for a shorthand volume."""
+    _, basename = parse_shorthand(volume)
+    return f"{SHORTHAND_CONTAINER_PREFIX}/{basename}"
+
+
+def container_path_of(volume: str) -> str:
+    """Return the container-side path for any volume entry (shorthand or full)."""
+    if is_shorthand_volume(volume):
+        return shorthand_container_path(volume)
+    return volume.split(":")[1]
 
 
 def ensure_selinux_label(volume: str) -> str:
@@ -104,15 +155,21 @@ def _expand_side(path: str, home: str, workspace: Optional[str]) -> str:
 def expand_volume(volume: str, context: VolumeContext) -> str:
     """Expand ~ , $HOME, $WORKSPACE, and shorthand in a volume string.
 
-    Shorthand (a bare name like 'outputs') expands to
-    '{project_dir}/{name}:/data/{name}'. For explicit host:container strings,
-    each side of the colon is expanded independently using the appropriate
-    home and workspace paths.
+    Shorthand (no colon) expands to '<host>:/data/<basename>'. Relative host
+    paths are anchored to project_dir; absolute and '~' / '$' prefixes are
+    self-sufficient and use normal variable expansion.
     """
     if is_shorthand_volume(volume):
-        validate_shorthand_name(volume)
-        host_base = context.project_dir or "."
-        return f"{host_base}/{volume}:{SHORTHAND_CONTAINER_PREFIX}/{volume}"
+        host, basename = parse_shorthand(volume)
+        container = f"{SHORTHAND_CONTAINER_PREFIX}/{basename}"
+        if _host_needs_anchor(host):
+            host_base = context.project_dir or "."
+            resolved = f"{host_base}/{host}"
+            if context.project_dir and os.path.isabs(context.project_dir):
+                resolved = os.path.normpath(resolved)
+            return f"{resolved}:{container}"
+        expanded_host = _expand_side(host, context.user_home, context.workspace_user)
+        return f"{expanded_host}:{container}"
 
     parts = volume.split(":")
     if len(parts) < 2:
@@ -141,10 +198,22 @@ def expand_volumes_for_script(volumes: List[str], container_home: str) -> List[s
     result = []
     for volume in volumes:
         if is_shorthand_volume(volume):
-            validate_shorthand_name(volume)
-            result.append(
-                f"${{_RUN_SH_DIR}}/{volume}:{SHORTHAND_CONTAINER_PREFIX}/{volume}"
-            )
+            host, basename = parse_shorthand(volume)
+            container = f"{SHORTHAND_CONTAINER_PREFIX}/{basename}"
+            if _host_needs_anchor(host):
+                result.append(f"${{_RUN_SH_DIR}}/{host}:{container}")
+                continue
+            if _has_workspace_variable(host):
+                print(
+                    f"Warning: Volume '{volume}' uses $WORKSPACE and will only "
+                    f"apply during development (cm run). The generated run.sh "
+                    f"does not include it because the workspace is expected to "
+                    f"be baked into the production image.",
+                    file=sys.stderr,
+                )
+                continue
+            expanded_host = _expand_side(host, "$HOME", workspace=None)
+            result.append(f"{expanded_host}:{container}")
             continue
 
         if _has_workspace_variable(volume):

--- a/src/container_magic/core/volumes.py
+++ b/src/container_magic/core/volumes.py
@@ -5,6 +5,28 @@ import sys
 from dataclasses import dataclass
 from typing import List, Optional
 
+SHORTHAND_CONTAINER_PREFIX = "/data"
+_SHORTHAND_NAME_PATTERN = re.compile(r"^[a-zA-Z0-9_-]+$")
+
+
+def is_shorthand_volume(volume: str) -> bool:
+    """Return True if the volume string is shorthand (a bare name, no colon)."""
+    return ":" not in volume
+
+
+def validate_shorthand_name(name: str) -> None:
+    """Raise ValueError if a shorthand volume name is malformed."""
+    if not _SHORTHAND_NAME_PATTERN.match(name):
+        raise ValueError(
+            f"Invalid shorthand volume '{name}': bare names must match "
+            f"[a-zA-Z0-9_-]+. Use 'host:container' for anything else."
+        )
+
+
+def shorthand_names(volumes: List[str]) -> List[str]:
+    """Return the bare names of shorthand entries from a volumes list."""
+    return [v for v in volumes if is_shorthand_volume(v)]
+
 
 def ensure_selinux_label(volume: str) -> str:
     """Append an SELinux :z label to a volume string if not already present.
@@ -44,12 +66,15 @@ class VolumeContext:
     container_home: home directory inside the container.
     workspace_user: absolute workspace path on the user side (only for cm run).
     workspace_container: absolute workspace path inside the container.
+    project_dir: absolute project root on the user side, used to resolve
+        shorthand volumes to an absolute host path.
     """
 
     user_home: str
     container_home: str
     workspace_user: Optional[str] = None
     workspace_container: Optional[str] = None
+    project_dir: Optional[str] = None
 
 
 _VARIABLE_PATTERN = re.compile(r"^(?:~(?=/|$)|\$HOME(?=/|$)|\$WORKSPACE(?=/|$))")
@@ -77,11 +102,18 @@ def _expand_side(path: str, home: str, workspace: Optional[str]) -> str:
 
 
 def expand_volume(volume: str, context: VolumeContext) -> str:
-    """Expand ~ , $HOME, and $WORKSPACE in a volume string.
+    """Expand ~ , $HOME, $WORKSPACE, and shorthand in a volume string.
 
-    Each side of the colon is expanded independently using the appropriate
+    Shorthand (a bare name like 'outputs') expands to
+    '{project_dir}/{name}:/data/{name}'. For explicit host:container strings,
+    each side of the colon is expanded independently using the appropriate
     home and workspace paths.
     """
+    if is_shorthand_volume(volume):
+        validate_shorthand_name(volume)
+        host_base = context.project_dir or "."
+        return f"{host_base}/{volume}:{SHORTHAND_CONTAINER_PREFIX}/{volume}"
+
     parts = volume.split(":")
     if len(parts) < 2:
         return volume
@@ -95,16 +127,12 @@ def expand_volume(volume: str, context: VolumeContext) -> str:
     return ":".join(expanded_parts)
 
 
-def expand_volumes_for_run(
-    volumes: List[str], context: VolumeContext
-) -> List[str]:
+def expand_volumes_for_run(volumes: List[str], context: VolumeContext) -> List[str]:
     """Expand variables in volumes for cm run (development)."""
     return [expand_volume(v, context) for v in volumes]
 
 
-def expand_volumes_for_script(
-    volumes: List[str], container_home: str
-) -> List[str]:
+def expand_volumes_for_script(volumes: List[str], container_home: str) -> List[str]:
     """Expand variables in volumes for run.sh generation (production).
 
     User-side ~ and $HOME are rendered as $HOME for shell expansion at runtime.
@@ -112,6 +140,13 @@ def expand_volumes_for_script(
     """
     result = []
     for volume in volumes:
+        if is_shorthand_volume(volume):
+            validate_shorthand_name(volume)
+            result.append(
+                f"${{_RUN_SH_DIR}}/{volume}:{SHORTHAND_CONTAINER_PREFIX}/{volume}"
+            )
+            continue
+
         if _has_workspace_variable(volume):
             print(
                 f"Warning: Volume '{volume}' uses $WORKSPACE and will only "

--- a/src/container_magic/generators/run_script.py
+++ b/src/container_magic/generators/run_script.py
@@ -15,7 +15,7 @@ from container_magic.core.templates import (
 from container_magic.core.volumes import (
     expand_volumes_for_script,
     label_volumes,
-    shorthand_names,
+    shorthand_anchored_paths,
 )
 
 
@@ -71,7 +71,7 @@ def generate_run_script(config: ContainerMagicConfig, project_dir: Path) -> None
     # Expand volume variables and apply SELinux labels for production context
     expanded_volumes = expand_volumes_for_script(effective_rt.volumes, workdir)
     expanded_volumes = label_volumes(expanded_volumes)
-    volume_shorthand = shorthand_names(effective_rt.volumes)
+    volume_shorthand = shorthand_anchored_paths(effective_rt.volumes)
 
     content = template.render(
         project_name=config.names.image,

--- a/src/container_magic/generators/run_script.py
+++ b/src/container_magic/generators/run_script.py
@@ -12,7 +12,11 @@ from container_magic.core.templates import (
     resolve_base_image,
     resolve_distro_shell,
 )
-from container_magic.core.volumes import expand_volumes_for_script, label_volumes
+from container_magic.core.volumes import (
+    expand_volumes_for_script,
+    label_volumes,
+    shorthand_names,
+)
 
 
 def generate_run_script(config: ContainerMagicConfig, project_dir: Path) -> None:
@@ -67,6 +71,7 @@ def generate_run_script(config: ContainerMagicConfig, project_dir: Path) -> None
     # Expand volume variables and apply SELinux labels for production context
     expanded_volumes = expand_volumes_for_script(effective_rt.volumes, workdir)
     expanded_volumes = label_volumes(expanded_volumes)
+    volume_shorthand = shorthand_names(effective_rt.volumes)
 
     content = template.render(
         project_name=config.names.image,
@@ -78,6 +83,7 @@ def generate_run_script(config: ContainerMagicConfig, project_dir: Path) -> None
         network=effective_rt.network_mode,
         features=features,
         volumes=expanded_volumes,
+        volume_shorthand=volume_shorthand,
         devices=effective_rt.devices,
         commands=commands_escaped,
         ipc=effective_rt.ipc,

--- a/src/container_magic/templates/run.sh.j2
+++ b/src/container_magic/templates/run.sh.j2
@@ -10,6 +10,7 @@ TAG="latest"
 WORKDIR="{{ workdir }}"
 WORKSPACE_NAME="{{ workspace_name }}"
 SHELL="{{ shell }}"
+_RUN_SH_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Detect runtime backend
 {%- if backend == "auto" %}
@@ -98,6 +99,13 @@ BASE_RUN_ARGS+=("--privileged")
 {%- endif %}
 {%- if network %}
 BASE_RUN_ARGS+=("--net" "{{ network }}")
+{%- endif %}
+{%- if volume_shorthand %}
+
+# Create host folders for shorthand volumes (siblings to run.sh)
+{%- for name in volume_shorthand %}
+mkdir -p "${_RUN_SH_DIR}/{{ name }}"
+{%- endfor %}
 {%- endif %}
 {%- if volumes %}
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -130,23 +130,37 @@ def test_invalid_volume_format():
 
 
 def test_volume_shorthand_accepted():
-    """Test that bare names are accepted as shorthand volumes."""
+    """Test that shorthand host paths are accepted in all supported forms."""
     config = ContainerMagicConfig(
         names={"image": "test", "user": "root"},
-        runtime={"volumes": ["outputs", "my-cache_2"]},
+        runtime={
+            "volumes": [
+                "outputs",
+                "my-cache_2",
+                "../shared",
+                "/srv/pipeline/data",
+                "~/datasets",
+            ]
+        },
         stages={
             "base": {"from": "debian:bookworm-slim"},
             "development": {"from": "base"},
             "production": {"from": "base"},
         },
     )
-    assert config.runtime.volumes == ["outputs", "my-cache_2"]
+    assert config.runtime.volumes == [
+        "outputs",
+        "my-cache_2",
+        "../shared",
+        "/srv/pipeline/data",
+        "~/datasets",
+    ]
 
 
 def test_invalid_shorthand_volume_rejected():
-    """Test that malformed shorthand names are rejected."""
-    for bad in ["out/puts", "out.puts", "out puts", ".."]:
-        with pytest.raises(ValidationError, match="bare names must match"):
+    """Test that shorthand entries with invalid basenames are rejected."""
+    for bad in ["out.puts", "out puts", "..", "../..", "/"]:
+        with pytest.raises(ValidationError):
             ContainerMagicConfig(
                 names={"image": "test", "user": "root"},
                 runtime={"volumes": [bad]},
@@ -156,6 +170,34 @@ def test_invalid_shorthand_volume_rejected():
                     "production": {"from": "base"},
                 },
             )
+
+
+def test_volume_collision_rejected():
+    """Test that two volumes mounting at the same container path are rejected."""
+    with pytest.raises(ValidationError, match="collision"):
+        ContainerMagicConfig(
+            names={"image": "test", "user": "root"},
+            runtime={"volumes": ["outputs", "../outputs"]},
+            stages={
+                "base": {"from": "debian:bookworm-slim"},
+                "development": {"from": "base"},
+                "production": {"from": "base"},
+            },
+        )
+
+
+def test_volume_collision_between_shorthand_and_full_rejected():
+    """Test collision detection across shorthand and full-form volumes."""
+    with pytest.raises(ValidationError, match="collision"):
+        ContainerMagicConfig(
+            names={"image": "test", "user": "root"},
+            runtime={"volumes": ["outputs", "/elsewhere:/data/outputs"]},
+            stages={
+                "base": {"from": "debian:bookworm-slim"},
+                "development": {"from": "base"},
+                "production": {"from": "base"},
+            },
+        )
 
 
 def test_invalid_volume_empty_parts():

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -120,13 +120,42 @@ def test_invalid_volume_format():
     with pytest.raises(ValidationError, match="Invalid volume format"):
         ContainerMagicConfig(
             names={"image": "test", "user": "root"},
-            runtime={"volumes": ["no-colon"]},
+            runtime={"volumes": [":/container"]},
             stages={
                 "base": {"from": "debian:bookworm-slim"},
                 "development": {"from": "base"},
                 "production": {"from": "base"},
             },
         )
+
+
+def test_volume_shorthand_accepted():
+    """Test that bare names are accepted as shorthand volumes."""
+    config = ContainerMagicConfig(
+        names={"image": "test", "user": "root"},
+        runtime={"volumes": ["outputs", "my-cache_2"]},
+        stages={
+            "base": {"from": "debian:bookworm-slim"},
+            "development": {"from": "base"},
+            "production": {"from": "base"},
+        },
+    )
+    assert config.runtime.volumes == ["outputs", "my-cache_2"]
+
+
+def test_invalid_shorthand_volume_rejected():
+    """Test that malformed shorthand names are rejected."""
+    for bad in ["out/puts", "out.puts", "out puts", ".."]:
+        with pytest.raises(ValidationError, match="bare names must match"):
+            ContainerMagicConfig(
+                names={"image": "test", "user": "root"},
+                runtime={"volumes": [bad]},
+                stages={
+                    "base": {"from": "debian:bookworm-slim"},
+                    "development": {"from": "base"},
+                    "production": {"from": "base"},
+                },
+            )
 
 
 def test_invalid_volume_empty_parts():

--- a/tests/unit/test_volumes.py
+++ b/tests/unit/test_volumes.py
@@ -1,5 +1,7 @@
 """Unit tests for volume SELinux labelling and variable expansion."""
 
+import pytest
+
 from container_magic.core.volumes import (
     VolumeContext,
     ensure_selinux_label,
@@ -7,7 +9,10 @@ from container_magic.core.volumes import (
     expand_volume,
     expand_volumes_for_run,
     expand_volumes_for_script,
+    is_shorthand_volume,
     label_volumes,
+    shorthand_names,
+    validate_shorthand_name,
 )
 
 
@@ -44,10 +49,16 @@ class TestEnsureSelinuxLabel:
         assert result == "/host/path:/container/path:ro,z"
 
     def test_named_volume(self):
-        assert ensure_selinux_label("myvolume:/container/path") == "myvolume:/container/path:z"
+        assert (
+            ensure_selinux_label("myvolume:/container/path")
+            == "myvolume:/container/path:z"
+        )
 
     def test_compound_options_with_nocopy(self):
-        assert ensure_selinux_label("/host:/container:ro,nocopy") == "/host:/container:ro,nocopy,z"
+        assert (
+            ensure_selinux_label("/host:/container:ro,nocopy")
+            == "/host:/container:ro,nocopy,z"
+        )
 
 
 class TestLabelVolumes:
@@ -55,11 +66,13 @@ class TestLabelVolumes:
         assert label_volumes([]) == []
 
     def test_mixed_volumes(self):
-        result = label_volumes([
-            "/tmp/data:/data:ro",
-            "/var/log:/logs",
-            "/host:/container:z",
-        ])
+        result = label_volumes(
+            [
+                "/tmp/data:/data:ro",
+                "/var/log:/logs",
+                "/host:/container:z",
+            ]
+        )
         assert result == [
             "/tmp/data:/data:ro,z",
             "/var/log:/logs:z",
@@ -73,6 +86,7 @@ def _make_context(**overrides):
         container_home="/home/appuser",
         workspace_user="/home/mark/repos/myproject/workspace",
         workspace_container="/home/appuser/workspace",
+        project_dir="/home/mark/repos/myproject",
     )
     defaults.update(overrides)
     return VolumeContext(**defaults)
@@ -98,8 +112,7 @@ class TestExpandVolume:
         ctx = _make_context()
         result = expand_volume("$WORKSPACE/output:$WORKSPACE/output", ctx)
         assert result == (
-            "/home/mark/repos/myproject/workspace/output:"
-            "/home/appuser/workspace/output"
+            "/home/mark/repos/myproject/workspace/output:/home/appuser/workspace/output"
         )
 
     def test_no_variables_unchanged(self):
@@ -127,10 +140,20 @@ class TestExpandVolume:
         result = expand_volume("~/.config:~/.config", ctx)
         assert result == "/home/mark/.config:/root/.config"
 
-    def test_single_part_unchanged(self):
+    def test_shorthand_expands_with_project_dir(self):
         ctx = _make_context()
-        result = expand_volume("named-volume", ctx)
-        assert result == "named-volume"
+        result = expand_volume("outputs", ctx)
+        assert result == "/home/mark/repos/myproject/outputs:/data/outputs"
+
+    def test_shorthand_expands_without_project_dir(self):
+        ctx = _make_context(project_dir=None)
+        result = expand_volume("outputs", ctx)
+        assert result == "./outputs:/data/outputs"
+
+    def test_shorthand_rejects_slash(self):
+        ctx = _make_context()
+        with pytest.raises(ValueError, match="bare names must match"):
+            expand_volume("outputs/sub", ctx)
 
     def test_tilde_alone(self):
         ctx = _make_context()
@@ -168,7 +191,7 @@ class TestExpandVolumesForScript:
         result = expand_volumes_for_script(
             ["~/.config/tool:~/.config/tool"],
             container_home="/home/appuser",
-            )
+        )
         assert result == ["$HOME/.config/tool:/home/appuser/.config/tool"]
 
     def test_dollar_home_rendered_as_shell_variable(self):
@@ -227,10 +250,79 @@ class TestExpandVolumesForScript:
         assert result == ["$HOME/.config:/root/.config"]
 
     def test_empty_list(self):
-        result = expand_volumes_for_script(
-            [], container_home="/home/appuser"
-        )
+        result = expand_volumes_for_script([], container_home="/home/appuser")
         assert result == []
+
+
+class TestShorthandHelpers:
+    def test_is_shorthand_volume_bare_name(self):
+        assert is_shorthand_volume("outputs") is True
+
+    def test_is_shorthand_volume_with_colon(self):
+        assert is_shorthand_volume("/host:/container") is False
+
+    def test_validate_shorthand_name_accepts_alnum(self):
+        validate_shorthand_name("outputs")
+        validate_shorthand_name("cache_2")
+        validate_shorthand_name("my-data-1")
+
+    def test_validate_shorthand_name_rejects_slash(self):
+        with pytest.raises(ValueError, match="bare names must match"):
+            validate_shorthand_name("outputs/sub")
+
+    def test_validate_shorthand_name_rejects_empty(self):
+        with pytest.raises(ValueError, match="bare names must match"):
+            validate_shorthand_name("")
+
+    def test_validate_shorthand_name_rejects_dotted(self):
+        with pytest.raises(ValueError, match="bare names must match"):
+            validate_shorthand_name("..")
+
+    def test_shorthand_names_filters_mixed(self):
+        result = shorthand_names(
+            [
+                "outputs",
+                "/tmp/x:/x",
+                "cache",
+                "~/a:~/a",
+            ]
+        )
+        assert result == ["outputs", "cache"]
+
+
+class TestExpandShorthandForRun:
+    def test_shorthand_expansion_absolute(self):
+        ctx = _make_context()
+        result = expand_volumes_for_run(["outputs"], ctx)
+        assert result == ["/home/mark/repos/myproject/outputs:/data/outputs"]
+
+    def test_mixed_shorthand_and_full(self):
+        ctx = _make_context()
+        result = expand_volumes_for_run(["outputs", "/tmp/data:/data:ro"], ctx)
+        assert result == [
+            "/home/mark/repos/myproject/outputs:/data/outputs",
+            "/tmp/data:/data:ro",
+        ]
+
+
+class TestExpandShorthandForScript:
+    def test_shorthand_uses_run_sh_dir(self):
+        result = expand_volumes_for_script(["outputs"], container_home="/home/appuser")
+        assert result == ["${_RUN_SH_DIR}/outputs:/data/outputs"]
+
+    def test_mixed_shorthand_and_full(self):
+        result = expand_volumes_for_script(
+            ["outputs", "~/.config:~/.config"],
+            container_home="/home/appuser",
+        )
+        assert result == [
+            "${_RUN_SH_DIR}/outputs:/data/outputs",
+            "$HOME/.config:/home/appuser/.config",
+        ]
+
+    def test_shorthand_invalid_name_raises(self):
+        with pytest.raises(ValueError, match="bare names must match"):
+            expand_volumes_for_script(["bad/name"], container_home="/home/appuser")
 
 
 class TestExpandMountPath:

--- a/tests/unit/test_volumes.py
+++ b/tests/unit/test_volumes.py
@@ -4,6 +4,7 @@ import pytest
 
 from container_magic.core.volumes import (
     VolumeContext,
+    container_path_of,
     ensure_selinux_label,
     expand_mount_path,
     expand_volume,
@@ -11,8 +12,9 @@ from container_magic.core.volumes import (
     expand_volumes_for_script,
     is_shorthand_volume,
     label_volumes,
-    shorthand_names,
-    validate_shorthand_name,
+    parse_shorthand,
+    shorthand_anchored_paths,
+    validate_shorthand_basename,
 )
 
 
@@ -150,10 +152,10 @@ class TestExpandVolume:
         result = expand_volume("outputs", ctx)
         assert result == "./outputs:/data/outputs"
 
-    def test_shorthand_rejects_slash(self):
+    def test_shorthand_relative_path_basename(self):
         ctx = _make_context()
-        with pytest.raises(ValueError, match="bare names must match"):
-            expand_volume("outputs/sub", ctx)
+        result = expand_volume("outputs/sub", ctx)
+        assert result == "/home/mark/repos/myproject/outputs/sub:/data/sub"
 
     def test_tilde_alone(self):
         ctx = _make_context()
@@ -261,33 +263,69 @@ class TestShorthandHelpers:
     def test_is_shorthand_volume_with_colon(self):
         assert is_shorthand_volume("/host:/container") is False
 
-    def test_validate_shorthand_name_accepts_alnum(self):
-        validate_shorthand_name("outputs")
-        validate_shorthand_name("cache_2")
-        validate_shorthand_name("my-data-1")
+    def test_validate_basename_accepts_alnum(self):
+        validate_shorthand_basename("outputs")
+        validate_shorthand_basename("cache_2")
+        validate_shorthand_basename("my-data-1")
 
-    def test_validate_shorthand_name_rejects_slash(self):
-        with pytest.raises(ValueError, match="bare names must match"):
-            validate_shorthand_name("outputs/sub")
+    def test_validate_basename_rejects_slash(self):
+        with pytest.raises(ValueError, match="must match"):
+            validate_shorthand_basename("outputs/sub")
 
-    def test_validate_shorthand_name_rejects_empty(self):
-        with pytest.raises(ValueError, match="bare names must match"):
-            validate_shorthand_name("")
+    def test_validate_basename_rejects_empty(self):
+        with pytest.raises(ValueError, match="must match"):
+            validate_shorthand_basename("")
 
-    def test_validate_shorthand_name_rejects_dotted(self):
-        with pytest.raises(ValueError, match="bare names must match"):
-            validate_shorthand_name("..")
+    def test_validate_basename_rejects_dotted(self):
+        with pytest.raises(ValueError, match="must match"):
+            validate_shorthand_basename("..")
 
-    def test_shorthand_names_filters_mixed(self):
-        result = shorthand_names(
+    def test_parse_shorthand_bare(self):
+        assert parse_shorthand("outputs") == ("outputs", "outputs")
+
+    def test_parse_shorthand_relative(self):
+        assert parse_shorthand("../shared") == ("../shared", "shared")
+
+    def test_parse_shorthand_absolute(self):
+        assert parse_shorthand("/srv/pipeline/outputs") == (
+            "/srv/pipeline/outputs",
+            "outputs",
+        )
+
+    def test_parse_shorthand_home_prefixed(self):
+        assert parse_shorthand("~/datasets") == ("~/datasets", "datasets")
+
+    def test_parse_shorthand_strips_trailing_slash(self):
+        assert parse_shorthand("../shared/") == ("../shared", "shared")
+
+    def test_parse_shorthand_rejects_empty(self):
+        with pytest.raises(ValueError, match="empty"):
+            parse_shorthand("")
+
+    def test_parse_shorthand_rejects_dotdot_basename(self):
+        with pytest.raises(ValueError, match="must match"):
+            parse_shorthand("../..")
+
+    def test_anchored_paths_filters_to_relative(self):
+        result = shorthand_anchored_paths(
             [
                 "outputs",
+                "../shared",
+                "/srv/data",
+                "~/datasets",
+                "$HOME/cache",
                 "/tmp/x:/x",
-                "cache",
-                "~/a:~/a",
             ]
         )
-        assert result == ["outputs", "cache"]
+        assert result == ["outputs", "../shared"]
+
+    def test_container_path_of_shorthand(self):
+        assert container_path_of("outputs") == "/data/outputs"
+        assert container_path_of("../shared") == "/data/shared"
+        assert container_path_of("/srv/out") == "/data/out"
+
+    def test_container_path_of_full_form(self):
+        assert container_path_of("/host:/mnt/data:ro") == "/mnt/data"
 
 
 class TestExpandShorthandForRun:
@@ -303,6 +341,26 @@ class TestExpandShorthandForRun:
             "/home/mark/repos/myproject/outputs:/data/outputs",
             "/tmp/data:/data:ro",
         ]
+
+    def test_shorthand_parent_dir_normalized(self):
+        ctx = _make_context()
+        result = expand_volumes_for_run(["../shared"], ctx)
+        assert result == ["/home/mark/repos/shared:/data/shared"]
+
+    def test_shorthand_absolute_host(self):
+        ctx = _make_context()
+        result = expand_volumes_for_run(["/srv/pipeline/outputs"], ctx)
+        assert result == ["/srv/pipeline/outputs:/data/outputs"]
+
+    def test_shorthand_home_expanded(self):
+        ctx = _make_context()
+        result = expand_volumes_for_run(["~/datasets"], ctx)
+        assert result == ["/home/mark/datasets:/data/datasets"]
+
+    def test_shorthand_trailing_slash_stripped(self):
+        ctx = _make_context()
+        result = expand_volumes_for_run(["../shared/"], ctx)
+        assert result == ["/home/mark/repos/shared:/data/shared"]
 
 
 class TestExpandShorthandForScript:
@@ -320,9 +378,27 @@ class TestExpandShorthandForScript:
             "$HOME/.config:/home/appuser/.config",
         ]
 
-    def test_shorthand_invalid_name_raises(self):
-        with pytest.raises(ValueError, match="bare names must match"):
-            expand_volumes_for_script(["bad/name"], container_home="/home/appuser")
+    def test_shorthand_parent_dir_relative_to_run_sh(self):
+        result = expand_volumes_for_script(
+            ["../shared"], container_home="/home/appuser"
+        )
+        assert result == ["${_RUN_SH_DIR}/../shared:/data/shared"]
+
+    def test_shorthand_absolute_host_passthrough(self):
+        result = expand_volumes_for_script(
+            ["/srv/pipeline/outputs"], container_home="/home/appuser"
+        )
+        assert result == ["/srv/pipeline/outputs:/data/outputs"]
+
+    def test_shorthand_home_rendered_as_dollar_home(self):
+        result = expand_volumes_for_script(
+            ["~/datasets"], container_home="/home/appuser"
+        )
+        assert result == ["$HOME/datasets:/data/datasets"]
+
+    def test_shorthand_invalid_basename_raises(self):
+        with pytest.raises(ValueError, match="must match"):
+            expand_volumes_for_script(["../.."], container_home="/home/appuser")
 
 
 class TestExpandMountPath:


### PR DESCRIPTION
Shorthand syntax for declaring data volumes without writing a full
host:container path. Any volume entry without a colon is treated as
shorthand: the container-side path is picked as `/data/<basename>` from
the host side, so `- outputs` expands to `./outputs:/data/outputs`.

Relative paths (bare names, `./`, `../`) are anchored to the project
directory in development and to the directory containing `run.sh` in
production; the host folder is created automatically if missing.
Absolute paths and `~` / `$` prefixes are self-sufficient and pass
through as-is (user is responsible for the folder existing).

Collision detection rejects two volume entries that resolve to the
same container path at config-parse time, instead of silently
clobbering at mount time.