### PR TITLE
feat(dockerfile)!: remove venv, install pip packages into base Python

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Build and run the production image:
 * **Automatic user handling** - host user identity in dev, dedicated user in prod, no manual setup
 * **GPU, display, and audio** - NVIDIA GPU passthrough, X11/Wayland forwarding, PulseAudio/PipeWire
 * **Custom commands** - define once, use in both dev and prod with port publishing and environment variables
-* **Multi-stage builds** - share steps between stages, automatic virtual environments for pip
+* **Multi-stage builds** - share steps between stages, pip packages install into the base image's Python (no venv duplication)
 * **Transparent execution** - run commands from anywhere in your repo with automatic path translation
 * **Data volumes** - shorthand for sibling folders (`outputs`, `cache`) that persist across runs without entering the image
 * **AWS credential forwarding** - mount host AWS config into the container

--- a/src/container_magic/generators/dockerfile.py
+++ b/src/container_magic/generators/dockerfile.py
@@ -178,7 +178,7 @@ def process_stage_steps(
     registry: Dict = None,
     asset_map: Dict[str, str] = None,
     workspace_symlinks: List[tuple] = None,
-    venv_active: bool = False,
+    pip_prepared: bool = False,
     implicit_user: bool = False,
 ) -> tuple:
     """Process build steps for a stage.
@@ -190,7 +190,7 @@ def process_stage_steps(
     symlink overlay data for the Dockerfile template.
 
     Returns:
-        (ordered_steps, venv_active) tuple
+        (ordered_steps, pip_prepared) tuple
     """
     if registry is None:
         registry = load_registry()
@@ -202,7 +202,7 @@ def process_stage_steps(
     # Default build order if not specified
     if stage.steps is None:
         if ":" in stage.frm or "/" in stage.frm:
-            return [], venv_active
+            return [], pip_prepared
         else:
             steps: List[Union[str, Dict[str, Any]]] = []
             if stage_name == "production":
@@ -235,13 +235,13 @@ def process_stage_steps(
     ordered_steps = []
 
     for step in steps:
-        if _step_is_pip(step) and not venv_active:
+        if _step_is_pip(step) and not pip_prepared:
             is_root = current_user is None
-            venv_step = {"type": "venv_setup", "is_root": is_root}
+            prepare_step = {"type": "prepare_pip", "is_root": is_root}
             if not is_root:
-                venv_step["restore_user"] = current_user
-            ordered_steps.append(venv_step)
-            venv_active = True
+                prepare_step["restore_user"] = current_user
+            ordered_steps.append(prepare_step)
+            pip_prepared = True
 
         parsed = parse_step(step, registry)
 
@@ -307,7 +307,7 @@ def process_stage_steps(
         elif step_type == "passthrough":
             ordered_steps.append({"type": "custom", "command": parsed["command"]})
 
-    return ordered_steps, venv_active
+    return ordered_steps, pip_prepared
 
 
 def generate_dockerfile(
@@ -369,7 +369,7 @@ def generate_dockerfile(
     leaf_stages = set(stages.keys()) - inherited_stages
 
     stages_data = []
-    venv_state: Dict[str, bool] = {}
+    pip_prepared_state: Dict[str, bool] = {}
     user_created_state: Dict[str, bool] = {}
     for stage_name, stage_config in stages.items():
         base_image = stage_config.frm
@@ -392,13 +392,13 @@ def generate_dockerfile(
         user_creation_style = distro_ucs or detect_user_creation_style(resolved_image)
 
         if from_is_image:
-            inherited_venv = False
+            inherited_pip_prepared = False
             inherited_user_created = False
         else:
-            inherited_venv = venv_state.get(base_image, False)
+            inherited_pip_prepared = pip_prepared_state.get(base_image, False)
             inherited_user_created = user_created_state.get(base_image, False)
 
-        ordered_steps, venv_active = process_stage_steps(
+        ordered_steps, pip_prepared = process_stage_steps(
             stage_config,
             stage_name,
             project_dir,
@@ -408,10 +408,10 @@ def generate_dockerfile(
             registry,
             asset_map,
             workspace_symlinks,
-            venv_active=inherited_venv,
+            pip_prepared=inherited_pip_prepared,
             implicit_user=implicit_user,
         )
-        venv_state[stage_name] = venv_active
+        pip_prepared_state[stage_name] = pip_prepared
 
         # Inject implicit create_user for from-image stages
         has_explicit_create_in_steps = any(
@@ -424,21 +424,6 @@ def generate_dockerfile(
             user_created_state[stage_name] = True
         else:
             user_created_state[stage_name] = inherited_user_created
-
-        # Chown venv to runtime user in leaf stages so it's writable in development
-        if has_user and stage_name in leaf_stages and venv_active:
-            # Determine if we're in a non-root context (inherited from parent)
-            last_become_user = None
-            for s in reversed(ordered_steps):
-                if s.get("type") == "become":
-                    last_become_user = s.get("name")
-                    break
-            inherited_context = _get_parent_user_context(stage_name, stages, user_name)
-            is_root = last_become_user is None and inherited_context is None
-            chown_step = {"type": "venv_chown", "is_root": is_root}
-            if not is_root:
-                chown_step["restore_user"] = last_become_user or inherited_context
-            ordered_steps.append(chown_step)
 
         # Inject implicit become at end of leaf stages only
         # Intermediate stages stay as root so child stages inherit root context

--- a/src/container_magic/templates/Dockerfile.j2
+++ b/src/container_magic/templates/Dockerfile.j2
@@ -34,53 +34,38 @@ ARG USER_GID={{ stage.user_gid }} \
 {% for step in stage.ordered_steps %}
 {% if step.type == "create_user" %}
 # Create user account (handles renaming if UID exists with different name)
+# hadolint ignore=DL4006
 {% if stage.user_creation_style == "alpine" %}
 RUN if [ "${USER_NAME}" != "root" ]; then \
-        # Check if the user already exists with exact match (name + uid + gid)
-        if getent passwd "${USER_UID}" | grep -q "^${USER_NAME}:"; then \
+        EXISTING_USER=$(getent passwd "${USER_UID}" | cut -d: -f1); \
+        if [ "${EXISTING_USER}" = "${USER_NAME}" ]; then \
             echo "User ${USER_NAME} with UID ${USER_UID} already exists, skipping creation"; \
+        elif [ -n "${EXISTING_USER}" ]; then \
+            echo "Renaming user ${EXISTING_USER} to ${USER_NAME}"; \
+            deluser "${EXISTING_USER}" && \
+            addgroup -g "${USER_GID}" "${USER_NAME}" 2>/dev/null; \
+            adduser -D -u "${USER_UID}" -G "${USER_NAME}" -h "${USER_HOME}" "${USER_NAME}"; \
         else \
-            # Check if UID exists with a different name
-            EXISTING_USER=$(getent passwd "${USER_UID}" | cut -d: -f1 || echo ""); \
-            if [ -n "${EXISTING_USER}" ] && [ "${EXISTING_USER}" != "${USER_NAME}" ]; then \
-                # Rename the existing user to our desired name
-                echo "Renaming user ${EXISTING_USER} to ${USER_NAME}"; \
-                deluser "${EXISTING_USER}"; \
-                addgroup -g "${USER_GID}" "${USER_NAME}" 2>/dev/null || true; \
-                adduser -D -u "${USER_UID}" -G "${USER_NAME}" -h "${USER_HOME}" "${USER_NAME}"; \
-            else \
-                # Create new user
-                if ! getent group "${USER_GID}" >/dev/null 2>&1; then \
-                    addgroup -g "${USER_GID}" "${USER_NAME}"; \
-                fi && \
-                adduser -D -u "${USER_UID}" -G "${USER_NAME}" -h "${USER_HOME}" "${USER_NAME}"; \
-            fi \
+            getent group "${USER_GID}" >/dev/null 2>&1 || \
+                addgroup -g "${USER_GID}" "${USER_NAME}"; \
+            adduser -D -u "${USER_UID}" -G "${USER_NAME}" -h "${USER_HOME}" "${USER_NAME}"; \
         fi && \
-        # Ensure home directory ownership (may have been created by WORKDIR)
         chown "${USER_UID}:${USER_GID}" "${USER_HOME}"; \
     fi
 {% else %}
 RUN if [ "${USER_NAME}" != "root" ]; then \
-        # Check if the user already exists with exact match (name + uid + gid)
-        if getent passwd "${USER_UID}" | grep -q "^${USER_NAME}:"; then \
+        EXISTING_USER=$(getent passwd "${USER_UID}" | cut -d: -f1); \
+        if [ "${EXISTING_USER}" = "${USER_NAME}" ]; then \
             echo "User ${USER_NAME} with UID ${USER_UID} already exists, skipping creation"; \
+        elif [ -n "${EXISTING_USER}" ]; then \
+            echo "Renaming user ${EXISTING_USER} to ${USER_NAME}"; \
+            usermod -l "${USER_NAME}" "${EXISTING_USER}" && \
+            usermod -d "${USER_HOME}" -m "${USER_NAME}" || true; \
         else \
-            # Check if UID exists with a different name
-            EXISTING_USER=$(getent passwd "${USER_UID}" | cut -d: -f1 || echo ""); \
-            if [ -n "${EXISTING_USER}" ] && [ "${EXISTING_USER}" != "${USER_NAME}" ]; then \
-                # Rename the existing user to our desired name
-                echo "Renaming user ${EXISTING_USER} to ${USER_NAME}"; \
-                usermod -l "${USER_NAME}" "${EXISTING_USER}" && \
-                usermod -d "${USER_HOME}" -m "${USER_NAME}" || true; \
-            else \
-                # Create new user
-                if ! getent group "${USER_GID}" >/dev/null 2>&1; then \
-                    groupadd --gid "${USER_GID}" "${USER_NAME}"; \
-                fi && \
-                useradd --uid "${USER_UID}" --gid "${USER_GID}" --home-dir "${USER_HOME}" --create-home "${USER_NAME}"; \
-            fi \
+            getent group "${USER_GID}" >/dev/null 2>&1 || \
+                groupadd --gid "${USER_GID}" "${USER_NAME}"; \
+            useradd --uid "${USER_UID}" --gid "${USER_GID}" --home-dir "${USER_HOME}" --create-home "${USER_NAME}"; \
         fi && \
-        # Ensure home directory ownership (may have been created by WORKDIR)
         chown "${USER_UID}:${USER_GID}" "${USER_HOME}"; \
     fi
 {% endif %}

--- a/src/container_magic/templates/Dockerfile.j2
+++ b/src/container_magic/templates/Dockerfile.j2
@@ -122,21 +122,16 @@ ENV {% for key, value in step.vars.items() %}{% if not loop.first %}    {% endif
 {% endif %}{% endfor %}
 
 {% endif %}
-{% elif step.type == "venv_setup" %}
+{% elif step.type == "prepare_pip" %}
 {% if not step.is_root %}
 USER root
 {% endif %}
-RUN test -f /opt/venv/pyvenv.cfg || python3 -m venv --system-site-packages /opt/venv
-ENV VIRTUAL_ENV=/opt/venv
-ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
-{% if not step.is_root %}
-USER {{ step.restore_user }}
-{% endif %}
-{% elif step.type == "venv_chown" %}
-{% if not step.is_root %}
-USER root
-{% endif %}
-RUN chown -R "${USER_UID}:${USER_GID}" /opt/venv
+# Disable PEP 668 (externally-managed-environment): host-system protection
+# against apt/pip conflicts, not applicable inside containers where the whole
+# environment is disposable.
+RUN rm -f /usr/lib/python*/EXTERNALLY-MANAGED \
+          /usr/local/lib/python*/EXTERNALLY-MANAGED \
+          /opt/conda/lib/python*/EXTERNALLY-MANAGED
 {% if not step.is_root %}
 USER {{ step.restore_user }}
 {% endif %}

--- a/tests/unit/test_implicit_user.py
+++ b/tests/unit/test_implicit_user.py
@@ -308,7 +308,7 @@ class TestDistroInheritance:
         assert "useradd" in other
 
 
-class TestImplicitUserWithVenv:
+class TestImplicitUserWithPip:
     def test_implicit_user_with_pip_step(self):
         """Pip step with implicit user creation should work correctly."""
         config = {
@@ -324,8 +324,8 @@ class TestImplicitUserWithVenv:
         }
         content = _generate(config)
         assert "useradd" in content
-        assert "python3 -m venv" in content
+        assert "# Disable PEP 668" in content
         lines = content.splitlines()
         create_idx = next(i for i, ln in enumerate(lines) if "useradd" in ln)
-        venv_idx = next(i for i, ln in enumerate(lines) if "venv" in ln and "RUN" in ln)
-        assert create_idx < venv_idx
+        marker_idx = next(i for i, ln in enumerate(lines) if "# Disable PEP 668" in ln)
+        assert create_idx < marker_idx

--- a/tests/unit/test_pip_venv.py
+++ b/tests/unit/test_pip_venv.py
@@ -1,4 +1,10 @@
-"""Tests for automatic venv creation on pip steps."""
+"""Tests for pip step handling.
+
+Pip packages install directly into the base image's Python, not into a venv.
+The only setup needed is removing the PEP 668 EXTERNALLY-MANAGED marker when
+present (Debian/Ubuntu with apt-installed Python), which is a host-system
+protection that doesn't apply inside containers.
+"""
 
 from tests.unit.conftest import generate_dockerfile_from_dict as _generate
 
@@ -16,21 +22,20 @@ def _base_config(**overrides):
     return config
 
 
-class TestVenvCreation:
-    def test_pip_as_root_creates_venv(self):
-        """First pip step as root injects venv setup."""
+class TestPipPreparation:
+    def test_pip_as_root_removes_marker(self):
+        """First pip step as root injects marker removal, no USER switch."""
         config = _base_config(steps=[{"pip": {"install": ["numpy"]}}])
         content = _generate(config)
-        assert "python3 -m venv --system-site-packages /opt/venv" in content
-        assert "ENV VIRTUAL_ENV=/opt/venv" in content
-        assert 'ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"' in content
-        # Should NOT have USER switching (already root)
+        assert "EXTERNALLY-MANAGED" in content
+        # No venv anywhere
+        assert "/opt/venv" not in content
+        assert "VIRTUAL_ENV" not in content
+        # No USER root before the marker removal line (already root)
         lines = content.splitlines()
-        venv_idx = next(
-            i for i, line in enumerate(lines) if "venv" in line and "RUN" in line
-        )
-        # No USER root before venv line
-        assert "USER root" not in lines[venv_idx - 1]
+        mm_idx = next(i for i, line in enumerate(lines) if "EXTERNALLY-MANAGED" in line)
+        preceding = [line.strip() for line in lines[:mm_idx] if line.strip()]
+        assert preceding[-1] != "USER root"
 
     def test_pip_after_become_user_switches_to_root(self):
         """Pip step after become: user injects USER root / USER restore."""
@@ -51,25 +56,19 @@ class TestVenvCreation:
         }
         content = _generate(config)
         lines = content.splitlines()
-        # Find venv creation
-        venv_idx = next(
-            i for i, line in enumerate(lines) if "venv" in line and "RUN" in line
-        )
-        # USER root before venv creation
-        preceding = [line.strip() for line in lines[:venv_idx] if line.strip()]
-        assert preceding[-1] == "USER root"
-        # USER restore after ENV PATH
-        path_idx = next(
-            i
-            for i, line in enumerate(lines)
-            if "VIRTUAL_ENV" in line and "PATH" in line
-        )
-        restore_lines = [line.strip() for line in lines[path_idx + 1 :] if line.strip()]
-        assert restore_lines[0].startswith("USER ")
-        assert restore_lines[0] != "USER root"
+        mm_idx = next(i for i, line in enumerate(lines) if "# Disable PEP 668" in line)
+        # USER root should appear in the prelude for the prepare_pip block
+        preceding = [line.strip() for line in lines[:mm_idx] if line.strip()]
+        # Walk back to find the nearest USER directive or other action
+        user_lines = [line for line in preceding if line.startswith("USER ")]
+        assert user_lines[-1] == "USER root"
+        # USER restore should come after the RUN rm line
+        trailing = [line.strip() for line in lines[mm_idx + 1 :] if line.strip()]
+        restore_user = next(line for line in trailing if line.startswith("USER "))
+        assert restore_user != "USER root"
 
-    def test_child_stage_inherits_venv(self):
-        """Pip step in child stage skips venv setup if parent already created one."""
+    def test_child_stage_skips_duplicate_marker_removal(self):
+        """Pip in child stage does not re-emit marker removal if parent did."""
         config = {
             "names": {"image": "test", "workspace": "workspace", "user": "appuser"},
             "stages": {
@@ -91,10 +90,10 @@ class TestVenvCreation:
             },
         }
         content = _generate(config)
-        assert content.count("python3 -m venv") == 1
+        assert content.count("# Disable PEP 668") == 1
 
-    def test_child_stage_without_parent_venv_creates_own(self):
-        """Pip step in child stage creates venv if parent had no pip steps."""
+    def test_child_stage_with_new_base_removes_marker(self):
+        """Pip in child stage without parent pip re-emits marker removal."""
         config = {
             "names": {"image": "test", "workspace": "workspace", "user": "appuser"},
             "stages": {
@@ -113,18 +112,16 @@ class TestVenvCreation:
             },
         }
         content = _generate(config)
-        assert "python3 -m venv" in content
-        assert "USER root" in content
+        assert "EXTERNALLY-MANAGED" in content
 
-    def test_no_pip_steps_no_venv(self):
-        """No venv setup when no pip steps exist."""
+    def test_no_pip_steps_no_marker_removal(self):
+        """No marker removal when no pip steps exist."""
         config = _base_config(steps=[{"run": "echo hello"}])
         content = _generate(config)
-        assert "venv" not in content
-        assert "VIRTUAL_ENV" not in content
+        assert "EXTERNALLY-MANAGED" not in content
 
-    def test_multiple_pip_steps_single_venv(self):
-        """Multiple pip steps in same stage only create venv once."""
+    def test_multiple_pip_steps_single_marker_removal(self):
+        """Multiple pip steps in the same stage only trigger marker removal once."""
         config = _base_config(
             steps=[
                 {"pip": {"install": ["numpy"]}},
@@ -132,37 +129,19 @@ class TestVenvCreation:
             ]
         )
         content = _generate(config)
-        assert content.count("python3 -m venv") == 1
-        assert content.count("ENV VIRTUAL_ENV=") == 1
-
-    def test_venv_env_ordering(self):
-        """VIRTUAL_ENV must be set before PATH references it."""
-        config = _base_config(steps=[{"pip": {"install": ["numpy"]}}])
-        content = _generate(config)
-        lines = content.splitlines()
-        venv_env_idx = next(
-            i for i, line in enumerate(lines) if "VIRTUAL_ENV=/opt/venv" in line
-        )
-        path_env_idx = next(
-            i for i, line in enumerate(lines) if "VIRTUAL_ENV}/bin" in line
-        )
-        assert venv_env_idx < path_env_idx
-
-    def test_venv_guard_prevents_clobbering(self):
-        """Venv creation uses test -f guard for idempotency."""
-        config = _base_config(steps=[{"pip": {"install": ["numpy"]}}])
-        content = _generate(config)
-        assert "test -f /opt/venv/pyvenv.cfg" in content
+        assert content.count("# Disable PEP 668") == 1
+        # Both pip installs should appear
+        assert content.count("pip install --no-cache-dir") == 2
 
     def test_pip_single_package_string(self):
-        """Pip step with single package as string (not list) also creates venv."""
+        """Pip step with single package as string (not list) works."""
         config = _base_config(steps=[{"pip": {"install": "requests"}}])
         content = _generate(config)
-        assert "python3 -m venv --system-site-packages /opt/venv" in content
+        assert "EXTERNALLY-MANAGED" in content
         assert "requests" in content
 
     def test_become_without_create_user(self):
-        """Pip after become to a pre-existing user (no create step) still switches to root."""
+        """Pip after become to a pre-existing user (no create step) wraps with USER root."""
         config = {
             "names": {"image": "test", "workspace": "workspace", "user": "root"},
             "stages": {
@@ -180,91 +159,10 @@ class TestVenvCreation:
         content = _generate(config)
         assert "USER root" in content
         assert "USER www-data" in content
-        assert "python3 -m venv" in content
+        assert "EXTERNALLY-MANAGED" in content
 
-    def test_venv_chowned_to_user_in_leaf_stage(self):
-        """Venv is chowned to the configured user so it's writable at runtime."""
-        config = {
-            "names": {"image": "test", "workspace": "workspace", "user": "appuser"},
-            "stages": {
-                "base": {
-                    "from": "debian:bookworm-slim",
-                    "steps": [
-                        {"pip": {"install": ["flask"]}},
-                    ],
-                },
-                "development": {"from": "base"},
-                "production": {"from": "base"},
-            },
-        }
-        content = _generate(config)
-        assert "chown -R" in content
-        assert "/opt/venv" in content
-
-    def test_venv_chown_not_added_for_root_user(self):
-        """No venv chown when user is root."""
-        config = _base_config(steps=[{"pip": {"install": ["numpy"]}}])
-        content = _generate(config)
-        assert (
-            "chown" not in content
-            or "USER_HOME" in content.split("chown")[0].split("\n")[-1]
-        )
-
-    def test_venv_chown_after_all_pip_steps(self):
-        """Venv chown appears after the last pip install, not between them."""
-        config = {
-            "names": {"image": "test", "workspace": "workspace", "user": "appuser"},
-            "stages": {
-                "base": {
-                    "from": "debian:bookworm-slim",
-                    "steps": [
-                        {"pip": {"install": ["flask"]}},
-                        {"pip": {"install": ["numpy"]}},
-                    ],
-                },
-                "development": {"from": "base"},
-                "production": {"from": "base"},
-            },
-        }
-        content = _generate(config)
-        lines = content.splitlines()
-        pip_lines = [i for i, line in enumerate(lines) if "pip install" in line]
-        chown_lines = [
-            i for i, line in enumerate(lines) if "chown" in line and "/opt/venv" in line
-        ]
-        assert len(chown_lines) >= 1
-        assert chown_lines[0] > pip_lines[-1]
-
-    def test_venv_chown_switches_to_root_when_base_has_become(self):
-        """Venv chown wraps with USER root when inheriting non-root context."""
-        config = {
-            "names": {"image": "test", "workspace": "workspace", "user": "appuser"},
-            "stages": {
-                "base": {
-                    "from": "debian:bookworm-slim",
-                    "steps": [
-                        {"pip": {"install": ["flask"]}},
-                        {"create": "user"},
-                        {"become": "user"},
-                    ],
-                },
-                "development": {"from": "base"},
-                "production": {"from": "base"},
-            },
-        }
-        content = _generate(config)
-        lines = content.splitlines()
-        chown_lines = [
-            i for i, line in enumerate(lines) if "chown" in line and "/opt/venv" in line
-        ]
-        assert len(chown_lines) >= 1
-        # USER root should appear before the chown
-        chown_idx = chown_lines[0]
-        preceding = [line.strip() for line in lines[:chown_idx] if line.strip()]
-        assert preceding[-1] == "USER root"
-
-    def test_stage_from_external_image_resets_venv(self):
-        """Stage from external image (not parent stage) starts fresh."""
+    def test_stage_from_external_image_removes_marker_again(self):
+        """Stage from a separate external image starts fresh and removes marker again."""
         config = {
             "names": {"image": "test", "workspace": "workspace", "user": "root"},
             "stages": {
@@ -281,4 +179,13 @@ class TestVenvCreation:
             },
         }
         content = _generate(config)
-        assert content.count("python3 -m venv") == 2
+        # Two independent FROM chains, each needs its own marker removal.
+        assert content.count("# Disable PEP 668") == 2
+
+    def test_no_opt_venv_anywhere(self):
+        """/opt/venv is no longer part of generated Dockerfiles."""
+        config = _base_config(steps=[{"pip": {"install": ["flask"]}}])
+        content = _generate(config)
+        assert "/opt/venv" not in content
+        assert "VIRTUAL_ENV" not in content
+        assert "python3 -m venv" not in content


### PR DESCRIPTION
Drop the /opt/venv layer entirely. Pip packages install directly into
the base image's Python. On images that already ship a Python
environment (pytorch/pytorch, python:3.11-slim, conda images), pip
sees existing packages and skips them - no more 7-8GB torch
duplication between /opt/conda and /opt/venv.

Before the first pip step, the generator emits a one-line 'rm -f' to
remove the PEP 668 EXTERNALLY-MANAGED marker on Debian/Ubuntu images.
PEP 668 is a host-system protection against apt/pip conflicts; it
doesn't apply in containers where the whole environment is disposable.

The create_user shell structure is also flattened to resolve a
shellcheck SC1075 error on generated Dockerfiles, and DL4006 is
suppressed on the user-creation RUN (the pipe semantics are
intentional).

## Breaking changes

- /opt/venv no longer exists in generated Dockerfiles.
- ENV VIRTUAL_ENV and the /opt/venv/bin PATH prefix are gone.
- Scripts that reference /opt/venv/bin/python must switch to
  /usr/bin/python3, /opt/conda/bin/python, or whichever Python the
  chosen base image provides.
- The runtime user no longer has write access to pip-installed
  packages by default. Interactive pip install inside a running
  container requires either 'pip install --user foo' or running the
  container with '--user 0'.