### PR TITLE
feat(dockerfile): precompile .pyc bytecode after pip installs

### DIFF
--- a/src/container_magic/generators/dockerfile.py
+++ b/src/container_magic/generators/dockerfile.py
@@ -190,7 +190,7 @@ def process_stage_steps(
     symlink overlay data for the Dockerfile template.
 
     Returns:
-        (ordered_steps, pip_prepared) tuple
+        (ordered_steps, pip_prepared, pip_used_in_stage) tuple
     """
     if registry is None:
         registry = load_registry()
@@ -199,10 +199,12 @@ def process_stage_steps(
     if workspace_symlinks is None:
         workspace_symlinks = []
 
+    pip_used_in_stage = False
+
     # Default build order if not specified
     if stage.steps is None:
         if ":" in stage.frm or "/" in stage.frm:
-            return [], pip_prepared
+            return [], pip_prepared, pip_used_in_stage
         else:
             steps: List[Union[str, Dict[str, Any]]] = []
             if stage_name == "production":
@@ -235,13 +237,15 @@ def process_stage_steps(
     ordered_steps = []
 
     for step in steps:
-        if _step_is_pip(step) and not pip_prepared:
-            is_root = current_user is None
-            prepare_step = {"type": "prepare_pip", "is_root": is_root}
-            if not is_root:
-                prepare_step["restore_user"] = current_user
-            ordered_steps.append(prepare_step)
-            pip_prepared = True
+        if _step_is_pip(step):
+            pip_used_in_stage = True
+            if not pip_prepared:
+                is_root = current_user is None
+                prepare_step = {"type": "prepare_pip", "is_root": is_root}
+                if not is_root:
+                    prepare_step["restore_user"] = current_user
+                ordered_steps.append(prepare_step)
+                pip_prepared = True
 
         parsed = parse_step(step, registry)
 
@@ -307,7 +311,7 @@ def process_stage_steps(
         elif step_type == "passthrough":
             ordered_steps.append({"type": "custom", "command": parsed["command"]})
 
-    return ordered_steps, pip_prepared
+    return ordered_steps, pip_prepared, pip_used_in_stage
 
 
 def generate_dockerfile(
@@ -398,7 +402,7 @@ def generate_dockerfile(
             inherited_pip_prepared = pip_prepared_state.get(base_image, False)
             inherited_user_created = user_created_state.get(base_image, False)
 
-        ordered_steps, pip_prepared = process_stage_steps(
+        ordered_steps, pip_prepared, pip_used_in_stage = process_stage_steps(
             stage_config,
             stage_name,
             project_dir,
@@ -424,6 +428,23 @@ def generate_dockerfile(
             user_created_state[stage_name] = True
         else:
             user_created_state[stage_name] = inherited_user_created
+
+        # Pre-compile .pyc bytecode for any packages added in this stage.
+        # Without this, the non-root runtime user can't write .pyc files to
+        # root-owned site-packages and every process pays the import-time
+        # compilation cost on startup. Build once, skip on every run.
+        if pip_used_in_stage:
+            last_become_user = None
+            for s in reversed(ordered_steps):
+                if s.get("type") == "become":
+                    last_become_user = s.get("name")
+                    break
+            inherited_context = _get_parent_user_context(stage_name, stages, user_name)
+            is_root = last_become_user is None and inherited_context is None
+            compile_step = {"type": "compile_bytecode", "is_root": is_root}
+            if not is_root:
+                compile_step["restore_user"] = last_become_user or inherited_context
+            ordered_steps.append(compile_step)
 
         # Inject implicit become at end of leaf stages only
         # Intermediate stages stay as root so child stages inherit root context

--- a/src/container_magic/templates/Dockerfile.j2
+++ b/src/container_magic/templates/Dockerfile.j2
@@ -120,6 +120,17 @@ RUN rm -f /usr/lib/python*/EXTERNALLY-MANAGED \
 {% if not step.is_root %}
 USER {{ step.restore_user }}
 {% endif %}
+{% elif step.type == "compile_bytecode" %}
+{% if not step.is_root %}
+USER root
+{% endif %}
+# Pre-compile .pyc bytecode so imports don't pay the compile cost on every
+# startup; the runtime user can't write .pyc back to root-owned site-packages.
+# hadolint ignore=SC2046
+RUN python3 -m compileall -q -j 0 $(python3 -c "import site; print(' '.join(site.getsitepackages()))")
+{% if not step.is_root %}
+USER {{ step.restore_user }}
+{% endif %}
 {% elif step.type == "custom" %}
 {% if step.command.startswith('ADD ') or step.command.startswith('ARG ') or step.command.startswith('CMD ') or step.command.startswith('COPY ') or step.command.startswith('ENTRYPOINT ') or step.command.startswith('ENV ') or step.command.startswith('EXPOSE ') or step.command.startswith('FROM ') or step.command.startswith('HEALTHCHECK ') or step.command.startswith('LABEL ') or step.command.startswith('RUN ') or step.command.startswith('SHELL ') or step.command.startswith('STOPSIGNAL ') or step.command.startswith('USER ') or step.command.startswith('VOLUME ') or step.command.startswith('WORKDIR ') %}
 {{ step.command }}

--- a/tests/unit/test_pip_venv.py
+++ b/tests/unit/test_pip_venv.py
@@ -189,3 +189,67 @@ class TestPipPreparation:
         assert "/opt/venv" not in content
         assert "VIRTUAL_ENV" not in content
         assert "python3 -m venv" not in content
+
+
+class TestCompileBytecode:
+    def test_compileall_emitted_after_pip(self):
+        """A stage with pip steps gets a compileall step after them."""
+        config = _base_config(steps=[{"pip": {"install": ["flask"]}}])
+        content = _generate(config)
+        assert "python3 -m compileall" in content
+        # compileall should come after the pip install
+        lines = content.splitlines()
+        pip_idx = next(i for i, ln in enumerate(lines) if "pip install" in ln)
+        compile_idx = next(i for i, ln in enumerate(lines) if "compileall" in ln)
+        assert compile_idx > pip_idx
+
+    def test_no_compileall_without_pip(self):
+        """Stages without pip don't emit compileall."""
+        config = _base_config(steps=[{"run": "echo hello"}])
+        content = _generate(config)
+        assert "compileall" not in content
+
+    def test_compileall_per_stage_that_adds_pip(self):
+        """Each stage that adds pip packages gets its own compileall."""
+        config = {
+            "names": {"image": "test", "workspace": "workspace", "user": "appuser"},
+            "stages": {
+                "base": {
+                    "from": "debian:bookworm-slim",
+                    "steps": [{"pip": {"install": ["flask"]}}],
+                },
+                "development": {
+                    "from": "base",
+                    "steps": [{"pip": {"install": ["pytest"]}}],
+                },
+                "production": {"from": "base"},
+            },
+        }
+        content = _generate(config)
+        # Base and development both add pip, both get compileall.
+        # Production inherits without adding - no compileall.
+        assert content.count("python3 -m compileall") == 2
+
+    def test_compileall_wraps_user_when_not_root(self):
+        """If end-of-stage user context is non-root, wrap with USER root."""
+        config = {
+            "names": {"image": "test", "workspace": "workspace", "user": "appuser"},
+            "stages": {
+                "base": {
+                    "from": "debian:bookworm-slim",
+                    "steps": [
+                        {"pip": {"install": ["flask"]}},
+                        {"create": "user"},
+                        {"become": "user"},
+                    ],
+                },
+                "development": {"from": "base"},
+                "production": {"from": "base"},
+            },
+        }
+        content = _generate(config)
+        lines = content.splitlines()
+        compile_idx = next(i for i, ln in enumerate(lines) if "compileall" in ln)
+        preceding = [line.strip() for line in lines[:compile_idx] if line.strip()]
+        user_lines = [line for line in preceding if line.startswith("USER ")]
+        assert user_lines[-1] == "USER root"


### PR DESCRIPTION
When pip installs into root-owned system site-packages, the non-root
runtime user cannot write .pyc cache files. Python silently falls back
to re-compiling .py files on every import in every process, costing
several seconds per startup on large packages like torch or whisperx.
For short-lived CLI workloads run repeatedly, the tax compounds.

After the last pip step in any stage that adds to site-packages, the
generator emits a 'python -m compileall' RUN. It runs as root at build
time, writes .pyc alongside .py, and lands in the image layer.
Runtime Python finds the cached .pyc and skips compilation entirely.

Child stages that only inherit without adding pip packages emit no
compileall - the inherited .pyc files from the parent stage are
already valid.