### PR TITLE
feat(registry): add conda/mamba/micromamba with channel field support

### DIFF
--- a/docs/build-steps.md
+++ b/docs/build-steps.md
@@ -380,6 +380,9 @@ Container-magic applies container-optimised defaults to each package manager aut
 | `apk add` | -- | `--no-cache` | -- |
 | `dnf install` | -- | `-y` | `dnf clean all` |
 | `pip install` | -- | `--no-cache-dir` | -- |
+| `conda install` | -- | `--yes --quiet --override-channels --channel conda-forge` | -- |
+| `mamba install` | -- | `--yes --quiet --override-channels --channel conda-forge` | -- |
+| `micromamba install` | -- | `--yes --quiet --override-channels --channel conda-forge` | -- |
 
 For example, this step:
 
@@ -404,7 +407,43 @@ src/container_magic/registry/
   apk.yaml
   dnf.yaml
   pip.yaml
+  conda.yaml
+  mamba.yaml
+  micromamba.yaml
 ```
+
+### Conda, Mamba, Micromamba
+
+Conda-style installers use `conda-forge` by default with `--override-channels` so
+any system `.condarc` is ignored. `conda-forge` is a community-maintained channel
+that is free to use; Anaconda Inc.'s `defaults` channel requires a paid commercial
+license in many cases, so container-magic steers clear of it unless you opt in.
+
+To use a different set of channels, list them on the step:
+
+```yaml
+- conda:
+    install:
+      - pytorch-cuda
+      - whisperx
+    channels:
+      - pytorch
+      - nvidia
+      - conda-forge
+```
+
+The channel order is priority order: the first listed is the highest priority.
+The generated command is:
+
+```dockerfile
+RUN conda install --yes --quiet --override-channels \
+    --channel pytorch --channel nvidia --channel conda-forge \
+    pytorch-cuda whisperx
+```
+
+`mamba:` and `micromamba:` accept the same `channels:` field with the same
+defaults. Pick whichever is installed in your base image - `conda` for the
+reference implementation, `mamba` or `micromamba` for faster installs.
 
 ### Per-project Overrides
 
@@ -432,13 +471,45 @@ install:
   cleanup: "pacman -Scc --noconfirm"
 ```
 
-Each entry supports three optional fields:
+Each entry supports the following optional fields:
 
 - `setup` -- command to run before the main command (e.g. updating the package index)
 - `flags` -- flags appended to the command line
 - `cleanup` -- command to run after the main command (e.g. clearing caches to reduce layer size)
+- `fields` -- declare step fields that expand to CLI flags (e.g. conda's `channels`)
 
-All three are combined into a single `RUN` instruction to keep the layer count down.
+All are combined into a single `RUN` instruction to keep the layer count down.
+
+#### Step fields that expand to flags
+
+When a tool accepts a flag that is repeated in priority order (like conda's
+`--channel`), the registry can declare a `fields` block so users list values
+naturally in their step rather than memorising a flag string:
+
+```yaml
+# src/container_magic/registry/conda.yaml
+install:
+  flags: "--yes --quiet --override-channels"
+  fields:
+    channels:
+      flag: "--channel"
+      default:
+        - conda-forge
+```
+
+A user step like `conda: {install: [pkg], channels: [a, b]}` expands to
+`conda install --yes --quiet --override-channels --channel a --channel b pkg`.
+If the user omits `channels:`, the `default` list is used.
+
+Each field spec takes:
+
+- `flag` -- the CLI flag name (e.g. `--channel`)
+- `default` -- a list of values applied when the user doesn't specify the field
+- `type` -- how to expand the values. Currently only `repeated_flag` (default)
+  is supported: one `<flag> <value>` pair per item in order.
+
+Field names on user steps that aren't declared in the registry are rejected
+with a clear error message listing the valid fields.
 
 ## Common Patterns
 

--- a/src/container_magic/core/registry.py
+++ b/src/container_magic/core/registry.py
@@ -39,7 +39,12 @@ class FieldSpec:
 
 
 class RegistryEntry:
-    """A single registry entry with optional setup, flags, cleanup, and fields."""
+    """A single registry entry with optional setup, flags, cleanup, and fields.
+
+    installs_python_packages signals to the Dockerfile generator that this
+    subcommand puts .py files into site-packages, so bytecode compilation
+    should run afterwards.
+    """
 
     def __init__(
         self,
@@ -47,16 +52,19 @@ class RegistryEntry:
         flags: str = "",
         cleanup: str = "",
         fields: Optional[Dict[str, FieldSpec]] = None,
+        installs_python_packages: bool = False,
     ):
         self.setup = setup
         self.flags = flags
         self.cleanup = cleanup
         self.fields = fields or {}
+        self.installs_python_packages = installs_python_packages
 
     def __repr__(self):
         return (
             f"RegistryEntry(setup={self.setup!r}, flags={self.flags!r}, "
-            f"cleanup={self.cleanup!r}, fields={self.fields!r})"
+            f"cleanup={self.cleanup!r}, fields={self.fields!r}, "
+            f"installs_python_packages={self.installs_python_packages!r})"
         )
 
 
@@ -86,6 +94,9 @@ def _entry_from_data(entry_data: Dict[str, Any]) -> RegistryEntry:
         flags=entry_data.get("flags", ""),
         cleanup=entry_data.get("cleanup", ""),
         fields=_parse_fields(entry_data.get("fields")),
+        installs_python_packages=bool(
+            entry_data.get("installs_python_packages", False)
+        ),
     )
 
 

--- a/src/container_magic/core/registry.py
+++ b/src/container_magic/core/registry.py
@@ -6,7 +6,7 @@ to retrieve flags and cleanup commands.
 """
 
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 import yaml
 
@@ -14,16 +14,79 @@ import yaml
 _REGISTRY_DIR = Path(__file__).parent.parent / "registry"
 
 
-class RegistryEntry:
-    """A single registry entry with optional setup, flags and cleanup."""
+class FieldSpec:
+    """A step field that maps to one or more CLI flags.
 
-    def __init__(self, setup: str = "", flags: str = "", cleanup: str = ""):
+    type 'repeated_flag': each value in the user's list (or default) becomes
+    a '<flag> <value>' pair, in order. E.g. conda's channels.
+    """
+
+    def __init__(
+        self,
+        flag: str,
+        default: Optional[List[Any]] = None,
+        field_type: str = "repeated_flag",
+    ):
+        self.flag = flag
+        self.default = list(default) if default else []
+        self.type = field_type
+
+    def __repr__(self):
+        return (
+            f"FieldSpec(flag={self.flag!r}, default={self.default!r}, "
+            f"type={self.type!r})"
+        )
+
+
+class RegistryEntry:
+    """A single registry entry with optional setup, flags, cleanup, and fields."""
+
+    def __init__(
+        self,
+        setup: str = "",
+        flags: str = "",
+        cleanup: str = "",
+        fields: Optional[Dict[str, FieldSpec]] = None,
+    ):
         self.setup = setup
         self.flags = flags
         self.cleanup = cleanup
+        self.fields = fields or {}
 
     def __repr__(self):
-        return f"RegistryEntry(setup={self.setup!r}, flags={self.flags!r}, cleanup={self.cleanup!r})"
+        return (
+            f"RegistryEntry(setup={self.setup!r}, flags={self.flags!r}, "
+            f"cleanup={self.cleanup!r}, fields={self.fields!r})"
+        )
+
+
+def _parse_fields(fields_data: Any) -> Dict[str, FieldSpec]:
+    """Convert a registry YAML 'fields' block into a FieldSpec dict."""
+    if not isinstance(fields_data, dict):
+        return {}
+    result: Dict[str, FieldSpec] = {}
+    for field_name, spec in fields_data.items():
+        if not isinstance(spec, dict):
+            continue
+        flag = spec.get("flag")
+        if not flag:
+            continue
+        result[field_name] = FieldSpec(
+            flag=flag,
+            default=spec.get("default"),
+            field_type=spec.get("type", "repeated_flag"),
+        )
+    return result
+
+
+def _entry_from_data(entry_data: Dict[str, Any]) -> RegistryEntry:
+    """Build a RegistryEntry from a parsed YAML dict."""
+    return RegistryEntry(
+        setup=entry_data.get("setup", ""),
+        flags=entry_data.get("flags", ""),
+        cleanup=entry_data.get("cleanup", ""),
+        fields=_parse_fields(entry_data.get("fields")),
+    )
 
 
 def _load_builtin_registry() -> Dict[str, Dict[str, RegistryEntry]]:
@@ -43,11 +106,7 @@ def _load_builtin_registry() -> Dict[str, Dict[str, RegistryEntry]]:
         for subcommand, entry_data in data.items():
             if not isinstance(entry_data, dict):
                 continue
-            registry[tool_name][subcommand] = RegistryEntry(
-                setup=entry_data.get("setup", ""),
-                flags=entry_data.get("flags", ""),
-                cleanup=entry_data.get("cleanup", ""),
-            )
+            registry[tool_name][subcommand] = _entry_from_data(entry_data)
 
     return registry
 
@@ -71,11 +130,7 @@ def load_registry(
             for subcommand, entry_data in subcommands.items():
                 if not isinstance(entry_data, dict):
                     continue
-                registry[tool_name][subcommand] = RegistryEntry(
-                    setup=entry_data.get("setup", ""),
-                    flags=entry_data.get("flags", ""),
-                    cleanup=entry_data.get("cleanup", ""),
-                )
+                registry[tool_name][subcommand] = _entry_from_data(entry_data)
 
     return registry
 

--- a/src/container_magic/core/steps.py
+++ b/src/container_magic/core/steps.py
@@ -121,11 +121,13 @@ def build_command(
     tool: str,
     body: Any,
     registry_entry: Optional[RegistryEntry] = None,
+    field_values: Optional[Dict[str, Any]] = None,
 ) -> str:
     """Build a complete RUN command from a tool name and its body.
 
     Flattens the dict structure into a command, injects registry flags
-    after the subcommand, and appends cleanup if present.
+    after the subcommand, expands any field values declared by the registry
+    entry, and appends cleanup if present.
     """
     segments = [tool]
 
@@ -135,6 +137,17 @@ def build_command(
         segments.append(subcommand)
         if registry_entry.flags:
             segments.append(registry_entry.flags)
+        for field_name, spec in registry_entry.fields.items():
+            values = (
+                field_values[field_name]
+                if field_values and field_name in field_values
+                else spec.default
+            )
+            if not values:
+                continue
+            if spec.type == "repeated_flag":
+                for v in values:
+                    segments.append(f"{spec.flag} {v}")
         if isinstance(args_value, list):
             if len(args_value) > 1:
                 base = " ".join(segments)
@@ -302,16 +315,34 @@ def parse_dict_step(
     # Command builder - look up in registry
     from container_magic.core.registry import lookup as registry_lookup
 
-    # Determine subcommand for registry lookup
+    # Determine subcommand and field values for registry lookup.
+    # When value is a dict, one key should match a registered subcommand; any
+    # remaining keys are fields whose handling is declared on that subcommand's
+    # registry entry (e.g. conda's `channels`).
     subcommand = None
-    if isinstance(value, dict) and len(value) == 1:
-        subcommand = next(iter(value))
-
+    field_values: Dict[str, Any] = {}
     entry = None
-    if subcommand is not None:
-        entry = registry_lookup(registry, key, subcommand)
+    body = value
 
-    command = build_command(key, value, entry)
+    if isinstance(value, dict) and value:
+        matching = [k for k in value if registry_lookup(registry, key, k) is not None]
+        if len(matching) == 1:
+            subcommand = matching[0]
+            entry = registry_lookup(registry, key, subcommand)
+            body = {subcommand: value[subcommand]}
+            field_values = {k: v for k, v in value.items() if k != subcommand}
+            unknown = [f for f in field_values if f not in entry.fields]
+            if unknown:
+                valid = ", ".join(sorted(entry.fields)) or "(none)"
+                raise ValueError(
+                    f"Unknown field(s) {unknown!r} on step '{key}: {subcommand}'. "
+                    f"Valid fields: {valid}"
+                )
+        elif len(matching) == 0 and len(value) == 1:
+            # No registry entry for the subcommand - pass through as-is
+            body = value
+
+    command = build_command(key, body, entry, field_values)
     return {"type": "run", "command": command}
 
 

--- a/src/container_magic/generators/dockerfile.py
+++ b/src/container_magic/generators/dockerfile.py
@@ -168,6 +168,29 @@ def _step_is_pip(step: Union[str, Dict[str, Any]]) -> bool:
     return isinstance(step, dict) and len(step) == 1 and next(iter(step)) == "pip"
 
 
+def _step_installs_python_packages(
+    step: Union[str, Dict[str, Any]], registry: Dict
+) -> bool:
+    """Return True if the step's registry entry sets installs_python_packages.
+
+    Used to trigger PEP 668 marker removal and post-install bytecode
+    compilation. Any registered tool can opt in via its YAML file, not just pip.
+    """
+    from container_magic.core.registry import lookup as registry_lookup
+
+    if not isinstance(step, dict) or len(step) != 1:
+        return False
+    tool = next(iter(step))
+    value = step[tool]
+    if not isinstance(value, dict):
+        return False
+    for key in value:
+        entry = registry_lookup(registry, tool, key)
+        if entry is not None and entry.installs_python_packages:
+            return True
+    return False
+
+
 def process_stage_steps(
     stage: StageConfig,
     stage_name: str,
@@ -237,7 +260,7 @@ def process_stage_steps(
     ordered_steps = []
 
     for step in steps:
-        if _step_is_pip(step):
+        if _step_installs_python_packages(step, registry):
             pip_used_in_stage = True
             if not pip_prepared:
                 is_root = current_user is None

--- a/src/container_magic/registry/conda.yaml
+++ b/src/container_magic/registry/conda.yaml
@@ -1,5 +1,6 @@
 install:
   flags: "--yes --quiet --override-channels"
+  installs_python_packages: true
   fields:
     channels:
       flag: "--channel"

--- a/src/container_magic/registry/conda.yaml
+++ b/src/container_magic/registry/conda.yaml
@@ -1,0 +1,7 @@
+install:
+  flags: "--yes --quiet --override-channels"
+  fields:
+    channels:
+      flag: "--channel"
+      default:
+        - conda-forge

--- a/src/container_magic/registry/mamba.yaml
+++ b/src/container_magic/registry/mamba.yaml
@@ -1,5 +1,6 @@
 install:
   flags: "--yes --quiet --override-channels"
+  installs_python_packages: true
   fields:
     channels:
       flag: "--channel"

--- a/src/container_magic/registry/mamba.yaml
+++ b/src/container_magic/registry/mamba.yaml
@@ -1,0 +1,7 @@
+install:
+  flags: "--yes --quiet --override-channels"
+  fields:
+    channels:
+      flag: "--channel"
+      default:
+        - conda-forge

--- a/src/container_magic/registry/micromamba.yaml
+++ b/src/container_magic/registry/micromamba.yaml
@@ -1,5 +1,6 @@
 install:
   flags: "--yes --quiet --override-channels"
+  installs_python_packages: true
   fields:
     channels:
       flag: "--channel"

--- a/src/container_magic/registry/micromamba.yaml
+++ b/src/container_magic/registry/micromamba.yaml
@@ -1,0 +1,7 @@
+install:
+  flags: "--yes --quiet --override-channels"
+  fields:
+    channels:
+      flag: "--channel"
+      default:
+        - conda-forge

--- a/src/container_magic/registry/pip.yaml
+++ b/src/container_magic/registry/pip.yaml
@@ -1,2 +1,3 @@
 install:
   flags: "--no-cache-dir"
+  installs_python_packages: true

--- a/tests/unit/test_conda.py
+++ b/tests/unit/test_conda.py
@@ -1,0 +1,179 @@
+"""Tests for conda/mamba/micromamba step support and registry field expansion."""
+
+import pytest
+
+from container_magic.core.registry import load_registry
+from container_magic.core.steps import parse_step
+
+
+@pytest.fixture
+def registry():
+    return load_registry()
+
+
+class TestCondaInstall:
+    def test_default_channel_is_conda_forge(self, registry):
+        step = {"conda": {"install": ["pytorch", "whisperx"]}}
+        result = parse_step(step, registry)
+        command = result["command"]
+        assert command.startswith("conda install")
+        assert "--yes --quiet --override-channels" in command
+        assert "--channel conda-forge" in command
+        assert "pytorch" in command
+        assert "whisperx" in command
+
+    def test_explicit_channels_replace_default(self, registry):
+        step = {
+            "conda": {
+                "install": ["pytorch"],
+                "channels": ["pytorch", "nvidia", "conda-forge"],
+            }
+        }
+        result = parse_step(step, registry)
+        command = result["command"]
+        assert "--channel pytorch" in command
+        assert "--channel nvidia" in command
+        assert "--channel conda-forge" in command
+        # Order matters (priority)
+        assert (
+            command.index("--channel pytorch")
+            < command.index("--channel nvidia")
+            < command.index("--channel conda-forge")
+        )
+
+    def test_default_channel_not_duplicated_when_explicit(self, registry):
+        step = {
+            "conda": {
+                "install": ["pytorch"],
+                "channels": ["custom"],
+            }
+        }
+        result = parse_step(step, registry)
+        command = result["command"]
+        assert "--channel custom" in command
+        assert "--channel conda-forge" not in command
+
+    def test_single_channel(self, registry):
+        step = {
+            "conda": {
+                "install": ["pytorch"],
+                "channels": ["pytorch"],
+            }
+        }
+        result = parse_step(step, registry)
+        command = result["command"]
+        assert command.count("--channel") == 1
+        assert "--channel pytorch" in command
+
+    def test_override_channels_flag_baked_in(self, registry):
+        """--override-channels is part of the default flags so .condarc is ignored."""
+        step = {"conda": {"install": ["pytorch"]}}
+        result = parse_step(step, registry)
+        assert "--override-channels" in result["command"]
+
+    def test_unknown_field_raises_helpful_error(self, registry):
+        step = {
+            "conda": {
+                "install": ["pytorch"],
+                "chanel": ["conda-forge"],  # typo
+            }
+        }
+        with pytest.raises(ValueError, match="Unknown field"):
+            parse_step(step, registry)
+
+    def test_unknown_field_error_lists_valid_fields(self, registry):
+        step = {
+            "conda": {
+                "install": ["pytorch"],
+                "bogus": [],
+            }
+        }
+        with pytest.raises(ValueError, match="Valid fields: channels"):
+            parse_step(step, registry)
+
+
+class TestMambaAndMicromamba:
+    def test_mamba_uses_same_defaults(self, registry):
+        step = {"mamba": {"install": ["pytorch"]}}
+        result = parse_step(step, registry)
+        command = result["command"]
+        assert command.startswith("mamba install")
+        assert "--channel conda-forge" in command
+
+    def test_micromamba_uses_same_defaults(self, registry):
+        step = {"micromamba": {"install": ["pytorch"]}}
+        result = parse_step(step, registry)
+        command = result["command"]
+        assert command.startswith("micromamba install")
+        assert "--channel conda-forge" in command
+
+    def test_mamba_accepts_channels(self, registry):
+        step = {
+            "mamba": {
+                "install": ["pytorch"],
+                "channels": ["pytorch", "conda-forge"],
+            }
+        }
+        result = parse_step(step, registry)
+        command = result["command"]
+        assert "--channel pytorch" in command
+        assert "--channel conda-forge" in command
+
+
+class TestBackwardCompatibility:
+    def test_pip_still_works_without_fields(self, registry):
+        """pip has no fields declared; existing usage is unchanged."""
+        step = {"pip": {"install": ["flask"]}}
+        result = parse_step(step, registry)
+        command = result["command"]
+        assert command.startswith("pip install --no-cache-dir")
+        assert "flask" in command
+
+    def test_apt_get_still_works(self, registry):
+        step = {"apt-get": {"install": ["curl"]}}
+        result = parse_step(step, registry)
+        command = result["command"]
+        assert "apt-get update" in command
+        assert "apt-get install" in command
+        assert "curl" in command
+        assert "rm -rf /var/lib/apt/lists/*" in command
+
+
+class TestProjectOverride:
+    def test_project_can_override_conda_flags(self):
+        registry = load_registry(
+            project_overrides={
+                "conda": {
+                    "install": {
+                        "flags": "--yes --verbose",
+                    }
+                }
+            }
+        )
+        step = {"conda": {"install": ["pytorch"]}}
+        result = parse_step(step, registry)
+        command = result["command"]
+        assert "--verbose" in command
+        # Project override replaces the whole entry, so default channel field is gone too
+        assert "--channel" not in command
+
+    def test_project_can_add_fields_to_custom_tool(self):
+        """Project can define its own tool with fields."""
+        registry = load_registry(
+            project_overrides={
+                "my-tool": {
+                    "install": {
+                        "flags": "install",
+                        "fields": {
+                            "extras": {
+                                "flag": "--extra",
+                                "default": ["default-extra"],
+                            }
+                        },
+                    }
+                }
+            }
+        )
+        step = {"my-tool": {"install": ["thing"]}}
+        result = parse_step(step, registry)
+        assert "--extra default-extra" in result["command"]

--- a/tests/unit/test_pip_venv.py
+++ b/tests/unit/test_pip_venv.py
@@ -230,6 +230,55 @@ class TestCompileBytecode:
         # Production inherits without adding - no compileall.
         assert content.count("python3 -m compileall") == 2
 
+    def test_compileall_triggered_by_conda(self):
+        """conda install triggers compileall just like pip does."""
+        config = {
+            "names": {"image": "test", "workspace": "workspace", "user": "root"},
+            "stages": {
+                "base": {
+                    "from": "pytorch/pytorch:latest",
+                    "steps": [{"conda": {"install": ["whisperx"]}}],
+                },
+                "development": {"from": "base", "steps": []},
+                "production": {"from": "base", "steps": []},
+            },
+        }
+        content = _generate(config)
+        assert "python3 -m compileall" in content
+        # Also marker removal should be injected for conda
+        assert "# Disable PEP 668" in content
+
+    def test_compileall_triggered_by_mamba(self):
+        config = {
+            "names": {"image": "test", "workspace": "workspace", "user": "root"},
+            "stages": {
+                "base": {
+                    "from": "pytorch/pytorch:latest",
+                    "steps": [{"mamba": {"install": ["whisperx"]}}],
+                },
+                "development": {"from": "base", "steps": []},
+                "production": {"from": "base", "steps": []},
+            },
+        }
+        content = _generate(config)
+        assert "python3 -m compileall" in content
+
+    def test_no_compileall_for_apt_only_stage(self):
+        """apt-get installs don't trigger compileall (not a Python installer)."""
+        config = {
+            "names": {"image": "test", "workspace": "workspace", "user": "root"},
+            "stages": {
+                "base": {
+                    "from": "debian:bookworm-slim",
+                    "steps": [{"apt-get": {"install": ["curl"]}}],
+                },
+                "development": {"from": "base", "steps": []},
+                "production": {"from": "base", "steps": []},
+            },
+        }
+        content = _generate(config)
+        assert "compileall" not in content
+
     def test_compileall_wraps_user_when_not_root(self):
         """If end-of-stage user context is non-root, wrap with USER root."""
         config = {


### PR DESCRIPTION
Conda, mamba, and micromamba join pip as first-class step types. The
registry YAML schema gains a 'fields' concept that declares step
fields expanding to CLI flags at render time. Conda uses this for
'channels:' so users list channels naturally instead of overriding
the whole flags string:

    - conda:
        install: [pytorch]
        channels: [pytorch, nvidia, conda-forge]

Defaults to --override-channels --channel conda-forge, which sidesteps
Anaconda Inc.'s commercial license on the 'defaults' channel by using
the community-run conda-forge ecosystem exclusively.

Registry entries also gain an 'installs_python_packages' flag; pip,
conda, mamba, and micromamba opt in. The generator reads this flag
when deciding whether to emit PEP 668 marker removal and compileall,
so those behaviours are no longer hardcoded to pip.

mamba and micromamba are command-compatible with conda, so their
registry entries are identical. Users pick whichever their base image
has installed.