### PR TITLE
fix(dockerfile): resolve 'copy: workspace' keyword for renamed workspaces

### DIFF
--- a/src/container_magic/core/config.py
+++ b/src/container_magic/core/config.py
@@ -651,7 +651,9 @@ class ContainerMagicConfig(BaseModel):
                 if key == "copy" and isinstance(value, str):
                     # Single-token copies are workspace-style (copied into home)
                     if " " not in value.strip():
-                        if value.strip() == self.names.workspace:
+                        # The 'workspace' keyword and the literal configured
+                        # name both resolve to names.workspace.
+                        if value.strip() in ("workspace", self.names.workspace):
                             has_workspace_copy = True
                         else:
                             literal_copies.append(value.strip())

--- a/src/container_magic/generators/dockerfile.py
+++ b/src/container_magic/generators/dockerfile.py
@@ -306,8 +306,9 @@ def process_stage_steps(
         elif step_type == "copy_v2":
             for args in parsed["args_list"]:
                 resolved_args = _resolve_copy_source(args, asset_map)
-                # Single token matching workspace name becomes copy_workspace
-                if args.strip() == workspace_name:
+                # The 'workspace' keyword (and the literal configured name)
+                # become copy_workspace; both resolve to names.workspace.
+                if args.strip() in ("workspace", workspace_name):
                     symlink_data = [{"rel_path": rel} for rel in workspace_symlinks]
                     ordered_steps.append(
                         {

--- a/tests/unit/test_dockerfile_output.py
+++ b/tests/unit/test_dockerfile_output.py
@@ -142,6 +142,92 @@ class TestEmptyCopyArgs:
 
 
 # ---------------------------------------------------------------------------
+# 1.5 Workspace keyword resolution (copy: workspace) with a renamed workspace
+# ---------------------------------------------------------------------------
+
+
+class TestWorkspaceKeywordResolution:
+    """`copy: workspace` must resolve to names.workspace whatever its value.
+
+    build-steps.md documents `workspace` as a keyword that resolves to the
+    directory named by names.workspace. The bug: the resolution matched the
+    literal token against the configured *value*, so it only worked when
+    names.workspace == "workspace" and produced a malformed destination-less
+    COPY otherwise.
+    """
+
+    def _assert_no_bare_copy(self, content):
+        for line in content.splitlines():
+            stripped = line.strip()
+            if stripped.startswith("COPY"):
+                non_flag = [p for p in stripped.split() if not p.startswith("--")]
+                assert len(non_flag) >= 3, (
+                    f"COPY with insufficient arguments: {stripped}"
+                )
+
+    def _renamed_config(self, production_steps):
+        return {
+            "names": {"image": "test", "workspace": "docs", "user": "user"},
+            "stages": {
+                "base": {
+                    "from": "debian:bookworm-slim",
+                    "steps": [{"create": "user"}],
+                },
+                "development": {"from": "base", "steps": []},
+                "production": {"from": "base", "steps": production_steps},
+            },
+        }
+
+    def test_keyword_resolves_to_renamed_workspace(self):
+        config = self._renamed_config([{"become": "user"}, {"copy": "workspace"}])
+        content = _generate(config)
+        prod = _get_stage_block(content, "production")
+        assert "COPY --chown=${USER_NAME}:${USER_NAME} docs ${WORKSPACE}" in prod
+        self._assert_no_bare_copy(content)
+
+    def test_literal_workspace_name_still_resolves(self):
+        """Back-compat: the literal configured name keeps working."""
+        config = self._renamed_config([{"become": "user"}, {"copy": "docs"}])
+        content = _generate(config)
+        prod = _get_stage_block(content, "production")
+        assert "COPY --chown=${USER_NAME}:${USER_NAME} docs ${WORKSPACE}" in prod
+        self._assert_no_bare_copy(content)
+
+    def test_keyword_and_literal_produce_identical_output(self):
+        keyword = _generate(
+            self._renamed_config([{"become": "user"}, {"copy": "workspace"}])
+        )
+        literal = _generate(
+            self._renamed_config([{"become": "user"}, {"copy": "docs"}])
+        )
+        assert keyword == literal
+
+    def test_production_auto_default_resolves_to_renamed_workspace(self):
+        """Production with no steps injects copy: workspace, which must resolve."""
+        config = {
+            "names": {"image": "test", "workspace": "docs", "user": "user"},
+            "stages": {
+                "base": {
+                    "from": "debian:bookworm-slim",
+                    "steps": [{"create": "user"}],
+                },
+                "development": {"from": "base", "steps": []},
+                "production": {"from": "base"},
+            },
+        }
+        content = _generate(config)
+        prod = _get_stage_block(content, "production")
+        assert "docs ${WORKSPACE}" in prod
+        self._assert_no_bare_copy(content)
+
+    def test_keyword_does_not_trigger_spurious_workspace_warning(self, capsys):
+        config = self._renamed_config([{"become": "user"}, {"copy": "workspace"}])
+        _generate(config)
+        captured = capsys.readouterr()
+        assert "is not the defined workspace" not in captured.err
+
+
+# ---------------------------------------------------------------------------
 # 2.1 Stage preamble variants
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
The 'workspace' keyword in a single-token 'copy:' step was matched against
the configured names.workspace value rather than treated as a keyword. It
resolved only when names.workspace was the default "workspace"; any other
name (for example "docs") fell through to a plain copy and emitted a
malformed, destination-less 'COPY workspace'. Because the production
auto-default and the 'cm init' scaffold both inject the literal
'{copy: workspace}', every project that renamed its workspace was affected,
whether the step was implicit or written out explicitly.

A second site carried the same defect. The validate_user_and_workspace_steps
config validator also compared the token against the workspace value only, so
a renamed workspace classified 'copy: workspace' as a non-workspace directory
and printed a "is not the defined workspace" warning on every build, actively
steering users away from the documented keyword.

Both sites now accept the keyword and the literal configured name. 'copy:
workspace' resolves to names.workspace whatever its value, and 'copy: <name>'
continues to work for back-compatibility, matching what docs/build-steps.md
already documents. The keyword path also now carries workspace symlink-overlay
staging, which a renamed workspace previously lost by falling through to a
plain copy.

A separate, pre-existing issue remains out of scope here: a genuine
non-workspace single-token 'copy: somedir' still emits a destination-less
COPY rather than copying into the user's home as docs/build-steps.md
describes. Tracked as a follow-up in #64.