### PR TITLE
feat(runner): wrap custom commands with set -o pipefail

### DIFF
--- a/src/container_magic/core/runner.py
+++ b/src/container_magic/core/runner.py
@@ -473,6 +473,12 @@ def run_container(
         else:
             command_str = command_spec.command
 
+        # Enable pipefail so a failing element of a pipeline (e.g.
+        # `pytest | tee log`) propagates its non-zero exit instead of
+        # being masked by the last element. Suppressed on shells that
+        # lack the option (POSIX dash) so it degrades to a no-op.
+        command_str = f"set -o pipefail 2>/dev/null; {command_str}"
+
     else:
         # No custom command - pass args directly (exec form, no shell wrapping).
         # This matches docker run behaviour. Users who need shell features

--- a/src/container_magic/templates/run.sh.j2
+++ b/src/container_magic/templates/run.sh.j2
@@ -234,7 +234,9 @@ run_{{ command_name }}() {
 	# {{ command_spec.description }}
 	{%- endif %}
 	local RUN_ARGS=("${BASE_RUN_ARGS[@]}")
-	local CMD="{{ command_spec.command }}"
+	# pipefail so a failing element of a pipeline propagates its exit
+	# code; suppressed on shells without the option (degrades to no-op).
+	local CMD="set -o pipefail 2>/dev/null; {{ command_spec.command }}"
 	local EXTRA_ARGS=()
 
 	{%- if command_spec.env %}

--- a/tests/fixtures/configs/scenario_pipefail.yaml
+++ b/tests/fixtures/configs/scenario_pipefail.yaml
@@ -1,0 +1,25 @@
+# Scenario: custom command containing a pipeline whose first element fails
+# Tests: pipefail wrapper so the inner failure propagates instead of being
+# masked by the last pipe element
+names:
+  image: cm-scenario-pipefail
+  workspace: workspace
+  user: appuser
+
+stages:
+  base:
+    from: cm-test:debian
+
+  development:
+    from: base
+
+  production:
+    from: base
+
+commands:
+  pipefail:
+    command: sh -c 'exit 7' | cat
+    description: Failing pipeline (exit 7 piped to cat)
+  plain:
+    command: sh -c 'exit 0'
+    description: Succeeding command

--- a/tests/integration/test_custom_commands.py
+++ b/tests/integration/test_custom_commands.py
@@ -325,3 +325,38 @@ commands:
     assert '--publish" "8443:443"' in run_sh_content, (
         "run.sh missing --publish for port 8443"
     )
+
+
+def test_custom_commands_wrapped_with_pipefail(temp_project_dir):
+    """Custom command strings are prefixed with `set -o pipefail` in run.sh."""
+    result = subprocess.run(
+        ["cm", "init", "--here", "python"],
+        cwd=temp_project_dir,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, f"cm init failed: {result.stderr}"
+
+    config_file = temp_project_dir / "cm.yaml"
+    config_file.write_text(
+        config_file.read_text()
+        + """
+commands:
+  test:
+    command: "pytest workspace/tests | tee /tmp/log"
+"""
+    )
+
+    result = subprocess.run(
+        ["cm", "update"],
+        cwd=temp_project_dir,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, f"cm update failed: {result.stderr}"
+
+    run_sh_content = (temp_project_dir / "run.sh").read_text()
+    assert (
+        'local CMD="set -o pipefail 2>/dev/null; pytest workspace/tests | tee /tmp/log"'
+        in run_sh_content
+    ), "custom command not wrapped with pipefail in run.sh"

--- a/tests/integration/test_scenarios.py
+++ b/tests/integration/test_scenarios.py
@@ -85,9 +85,7 @@ def _build_and_run(project, command=None, timeout=300):
 
 def test_python_app(debian_base_image, tmp_path):
     """Basic Python app: pip install, workspace script imports package."""
-    project = _setup_project(
-        tmp_path, "scenario_python_app.yaml", ["check_import.py"]
-    )
+    project = _setup_project(tmp_path, "scenario_python_app.yaml", ["check_import.py"])
     result = _build_and_run(project, ["python3", "check_import.py"])
     assert result.returncode == 0, f"Script failed:\n{result.stderr}"
     assert "import_ok" in result.stdout
@@ -95,9 +93,7 @@ def test_python_app(debian_base_image, tmp_path):
 
 def test_multistage(debian_base_image, tmp_path):
     """Multi-stage: builder is intermediate, production is leaf with root-owned workspace."""
-    project = _setup_project(
-        tmp_path, "scenario_multistage.yaml", ["check_import.py"]
-    )
+    project = _setup_project(tmp_path, "scenario_multistage.yaml", ["check_import.py"])
     result = _build_and_run(project, ["python3", "check_import.py"])
     assert result.returncode == 0, f"Script failed:\n{result.stderr}"
     assert "import_ok" in result.stdout
@@ -123,9 +119,7 @@ def test_multistage(debian_base_image, tmp_path):
 
 def test_alpine(alpine_base_image, tmp_path):
     """Alpine with explicit overrides: pip install, workspace script runs."""
-    project = _setup_project(
-        tmp_path, "scenario_alpine.yaml", ["check_import.py"]
-    )
+    project = _setup_project(tmp_path, "scenario_alpine.yaml", ["check_import.py"])
     result = _build_and_run(project, ["python3", "check_import.py"])
     assert result.returncode == 0, f"Script failed:\n{result.stderr}"
     assert "import_ok" in result.stdout
@@ -133,9 +127,7 @@ def test_alpine(alpine_base_image, tmp_path):
 
 def test_custom_commands(debian_base_image, tmp_path):
     """Custom commands: env var is passed through and script reads it."""
-    project = _setup_project(
-        tmp_path, "scenario_commands.yaml", ["check_env.py"]
-    )
+    project = _setup_project(tmp_path, "scenario_commands.yaml", ["check_env.py"])
     _build_and_run(project)  # build only
 
     result = subprocess.run(
@@ -152,9 +144,7 @@ def test_custom_commands(debian_base_image, tmp_path):
 
 def test_root_user(debian_base_image, tmp_path):
     """Root user: no USER directives, script runs as root."""
-    project = _setup_project(
-        tmp_path, "scenario_root_user.yaml", ["check_user.py"]
-    )
+    project = _setup_project(tmp_path, "scenario_root_user.yaml", ["check_user.py"])
     result = _build_and_run(project, ["python3", "check_user.py"])
     assert result.returncode == 0, f"Script failed:\n{result.stderr}"
     assert "uid=0" in result.stdout
@@ -163,3 +153,39 @@ def test_root_user(debian_base_image, tmp_path):
     # Verify no USER directives in generated Dockerfile
     dockerfile = (project / "Dockerfile").read_text()
     assert "USER " not in dockerfile
+
+
+def test_custom_command_pipefail_propagates(debian_base_image, tmp_path):
+    """A failing element of a piped custom command propagates its exit code.
+
+    Without the pipefail wrapper, `sh -c 'exit 7' | cat` would exit 0 (cat's
+    status), masking the inner failure. With it, the run.sh invocation must
+    exit non-zero so scripted gates and CI catch the failure.
+    """
+    project = _setup_project(tmp_path, "scenario_pipefail.yaml")
+    _build_and_run(project)  # build only
+
+    failing = subprocess.run(
+        ["./run.sh", "pipefail"],
+        cwd=project,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert failing.returncode == 7, (
+        "piped custom command should propagate the inner non-zero exit, "
+        f"got {failing.returncode}\nstdout: {failing.stdout}\n"
+        f"stderr: {failing.stderr}"
+    )
+
+    passing = subprocess.run(
+        ["./run.sh", "plain"],
+        cwd=project,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert passing.returncode == 0, (
+        f"succeeding command should still exit 0, got {passing.returncode}\n"
+        f"stderr: {passing.stderr}"
+    )


### PR DESCRIPTION
Custom commands run through a shell, and by default a shell pipeline reports
only the exit status of its last element. A command like
'pytest tests/ | tee test.log' therefore exited 0 even when pytest failed,
because 'tee' succeeded - so a failing command run via 'cm' looked like it
passed, and anything keying off the exit code (CI, scripts, the caller's
'&&' chains) was misled.

Custom commands are now prefixed with 'set -o pipefail' so the pipeline takes
the exit status of the last element to fail. The option is applied in both
places a custom command is assembled: the Python runner that builds the
in-container command string, and the generated run.sh helper. It is written
as 'set -o pipefail 2>/dev/null; ...' so that shells without the option
(POSIX dash) silently ignore it and the command still runs - the behaviour
simply degrades to the previous last-element semantics rather than erroring.

Covered by an integration test asserting that a failing element of a piped
custom command propagates its non-zero exit code, plus a pipefail scenario
fixture.