### PR TITLE
fix(packaging): ship registry YAML files in the wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ Issues = "https://github.com/markhedleyjones/container-magic/issues"
 where = ["src"]
 
 [tool.setuptools.package-data]
-container_magic = ["templates/**/*"]
+container_magic = ["templates/**/*", "registry/*.yaml"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/tests/unit/test_packaging.py
+++ b/tests/unit/test_packaging.py
@@ -1,0 +1,47 @@
+"""Packaging guards: runtime data files must be shipped in the built wheel.
+
+These resources load by filesystem path from inside the installed package, so
+they are only present in a wheel if a ``[tool.setuptools.package-data]`` glob
+covers them. Editable/source installs always have them, which is how the
+missing ``registry/*.yaml`` glob went unnoticed until a clean wheel install.
+"""
+
+from fnmatch import fnmatch
+from pathlib import Path
+
+import pytest
+
+try:
+    import tomllib  # Python 3.11+
+except ModuleNotFoundError:  # pragma: no cover - exercised on <3.11 only
+    try:
+        import tomli as tomllib
+    except ModuleNotFoundError:  # pragma: no cover
+        tomllib = None
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_PKG = _REPO_ROOT / "src" / "container_magic"
+
+
+def _package_data_globs():
+    data = tomllib.loads((_REPO_ROOT / "pyproject.toml").read_text())
+    return data["tool"]["setuptools"]["package-data"]["container_magic"]
+
+
+@pytest.mark.skipif(tomllib is None, reason="no TOML parser available")
+def test_registry_yaml_files_are_in_package_data():
+    """Built-in registry YAML files load via filesystem path and must ship.
+
+    Regression: they were absent from package-data, so a clean wheel/PyPI
+    install had an empty registry and every apt-get/pip/apk/dnf step broke.
+    """
+    yamls = sorted((_PKG / "registry").glob("*.yaml"))
+    assert yamls, "expected built-in registry YAML files under registry/"
+
+    globs = _package_data_globs()
+    for yaml in yamls:
+        rel = f"registry/{yaml.name}"
+        assert any(fnmatch(rel, g) for g in globs), (
+            f"{rel} is not covered by package-data {globs}; "
+            "a wheel install would ship an empty registry"
+        )


### PR DESCRIPTION
The built-in registry YAML files (apt-get, apk, dnf, pip, conda, mamba,
micromamba) load by filesystem path from inside the installed package
(`Path(__file__).parent.parent / "registry"`), but `[tool.setuptools.package-data]`
only declared `templates/**/*`. The built wheel therefore contained
`registry/__init__.py` but none of the `registry/*.yaml` data files.

The effect on a clean wheel install - `pip install container-magic` from PyPI,
or any wheel-based install such as a Nix build - is an empty registry: every
`apt-get:`, `apk:`, `dnf:`, `pip:`, and conda-family step loses its
container-optimised defaults (setup/flags/cleanup) or fails the registry
lookup entirely. It went unnoticed because development and the documented
workflow use editable installs, which run from the source tree where the YAML
files are always present.

Adding `registry/*.yaml` to package-data bundles the data files. Verified by
building the wheel and confirming all seven YAMLs are now present alongside
the templates. A unit guard fails if a registry YAML ever falls outside the
package-data globs again.

An audit of every other runtime-loaded resource (templates, and the project
files the CLI reads such as `.dockerignore`/`Justfile`) confirmed registry was
the only gap - the rest are either already covered or live in the user's
project, not the package.