### PR TITLE
fix(dockerfile): give single-token non-workspace copy a destination

### DIFF
--- a/docs/build-steps.md
+++ b/docs/build-steps.md
@@ -24,7 +24,24 @@ stages:
 !!! note
     This is the automatic default step for the production stage if no steps are specified.
 
-A single-token `copy:` that does not match `names.workspace` is treated as a directory copy into the user's home, but container-magic will flag it:
+A single-token `copy:` that does not match `names.workspace` copies that directory into the user's home, beside the workspace. The destination defaults to the same name under the user's home directory (the build `WORKDIR`), so a top-level repo directory keeps its position as a sibling of the workspace inside the image:
+
+```yaml
+names:
+  workspace: docs
+  user: app
+
+stages:
+  production:
+    from: base
+    steps:
+      - copy: workspace   # COPY docs ${WORKSPACE}      -> ${USER_HOME}/docs
+      - copy: assets      # COPY assets ./assets         -> ${USER_HOME}/assets
+```
+
+For a nested source the basename is preserved (`copy: src/lib` -> `COPY src/lib ./lib`). To place a directory somewhere else, give an explicit destination (`copy: assets /opt/assets`).
+
+container-magic also flags single-token non-workspace copies, since they are often a mistake:
 
 - **Warning** if the workspace is never copied -- you probably meant `copy: workspace` or need to update `names.workspace`
 - **Info** if the workspace is also copied -- you're copying an extra directory alongside the workspace, which is fine

--- a/src/container_magic/generators/dockerfile.py
+++ b/src/container_magic/generators/dockerfile.py
@@ -163,6 +163,20 @@ def _resolve_copy_source(args: str, asset_map: Dict[str, str]) -> str:
     return args
 
 
+def _ensure_copy_destination(resolved_args: str, original_args: str) -> str:
+    """Give a destination-less single-token copy a sensible one.
+
+    A bare ``copy: <dir>`` (one token, no destination) copies the directory
+    into the user's home (WORKDIR) under the same name, mirroring the host
+    layout where it sits beside the workspace. Multi-token args (explicit
+    ``source dest``, ``--from=`` clauses, etc.) are returned unchanged.
+    """
+    if " " in resolved_args.strip():
+        return resolved_args
+    name = Path(original_args.strip()).name
+    return f"{resolved_args.strip()} ./{name}"
+
+
 def _step_is_pip(step: Union[str, Dict[str, Any]]) -> bool:
     """Check if a raw step is a pip step."""
     return isinstance(step, dict) and len(step) == 1 and next(iter(step)) == "pip"
@@ -301,6 +315,7 @@ def process_stage_steps(
             if chown == "context":
                 chown = current_user
             args = _resolve_copy_source(parsed["args"], asset_map)
+            args = _ensure_copy_destination(args, parsed["args"])
             ordered_steps.append({"type": "copy", "args": args, "chown": chown})
 
         elif step_type == "copy_v2":
@@ -318,8 +333,9 @@ def process_stage_steps(
                         }
                     )
                 else:
+                    final_args = _ensure_copy_destination(resolved_args, args)
                     ordered_steps.append(
-                        {"type": "copy", "args": resolved_args, "chown": current_user}
+                        {"type": "copy", "args": final_args, "chown": current_user}
                     )
 
         elif step_type == "env":

--- a/tests/unit/test_dockerfile_output.py
+++ b/tests/unit/test_dockerfile_output.py
@@ -228,6 +228,75 @@ class TestWorkspaceKeywordResolution:
 
 
 # ---------------------------------------------------------------------------
+# 1.6 Single-token non-workspace copy resolves into the user's home
+# ---------------------------------------------------------------------------
+
+
+class TestNonWorkspaceSingleTokenCopy:
+    """A single-token `copy: <dir>` that is not the workspace copies the
+    directory into the user's home as a sibling of the workspace, never a
+    destination-less COPY (docs/build-steps.md).
+    """
+
+    def _assert_no_bare_copy(self, content):
+        for line in content.splitlines():
+            stripped = line.strip()
+            if stripped.startswith("COPY"):
+                non_flag = [p for p in stripped.split() if not p.startswith("--")]
+                assert len(non_flag) >= 3, (
+                    f"COPY with insufficient arguments: {stripped}"
+                )
+
+    def _config(self, production_steps):
+        return {
+            "names": {"image": "test", "workspace": "docs", "user": "user"},
+            "stages": {
+                "base": {
+                    "from": "debian:bookworm-slim",
+                    "steps": [{"create": "user"}],
+                },
+                "development": {"from": "base", "steps": []},
+                "production": {"from": "base", "steps": production_steps},
+            },
+        }
+
+    def test_dict_single_token_copies_into_home(self):
+        content = _generate(self._config([{"become": "user"}, {"copy": "assets"}]))
+        prod = _get_stage_block(content, "production")
+        assert "COPY --chown=${USER_NAME}:${USER_NAME} assets ./assets" in prod
+        self._assert_no_bare_copy(content)
+
+    def test_bare_string_single_token_copies_into_home(self):
+        content = _generate(self._config([{"become": "user"}, "copy assets"]))
+        prod = _get_stage_block(content, "production")
+        assert "COPY --chown=${USER_NAME}:${USER_NAME} assets ./assets" in prod
+        self._assert_no_bare_copy(content)
+
+    def test_workspace_keyword_unaffected(self):
+        content = _generate(self._config([{"become": "user"}, {"copy": "workspace"}]))
+        prod = _get_stage_block(content, "production")
+        assert "COPY --chown=${USER_NAME}:${USER_NAME} docs ${WORKSPACE}" in prod
+        self._assert_no_bare_copy(content)
+
+    def test_multi_token_copy_unchanged(self):
+        content = _generate(
+            self._config([{"become": "user"}, {"copy": "config.yaml /etc/config.yaml"}])
+        )
+        prod = _get_stage_block(content, "production")
+        assert (
+            "COPY --chown=${USER_NAME}:${USER_NAME} config.yaml /etc/config.yaml"
+            in prod
+        )
+        self._assert_no_bare_copy(content)
+
+    def test_subpath_single_token_preserves_basename(self):
+        content = _generate(self._config([{"become": "user"}, {"copy": "src/lib"}]))
+        prod = _get_stage_block(content, "production")
+        assert "COPY --chown=${USER_NAME}:${USER_NAME} src/lib ./lib" in prod
+        self._assert_no_bare_copy(content)
+
+
+# ---------------------------------------------------------------------------
 # 2.1 Stage preamble variants
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
A single-token `copy: <dir>` whose argument was neither the `workspace`
keyword nor `names.workspace` produced a destination-less `COPY <dir>`, an
invalid instruction that failed the Docker build. docs/build-steps.md
documents this form as a directory copy into the user's home, beside the
workspace, but the generator never supplied the destination.

Such copies now default their destination to the same name under the build
WORKDIR (the user's home), so a top-level repo directory keeps its position
as a sibling of the workspace inside the image:

```
copy: assets   ->  COPY --chown=user:user assets ./assets
copy: src/lib  ->  COPY --chown=user:user src/lib ./lib
```

A nested source preserves its basename. Multi-token copies (explicit
`source dest`, `--from=` clauses) and the `workspace` keyword are unchanged.
The existing warning/info diagnostics for non-workspace copies are kept.