### PR TITLE
build(nix): add flake for nix run and declarative installs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1780243769,
+        "narHash": "sha256-x5UQuRsH3MqI0U9afaXSNqzTPSeZlRLvFAav2Ux1pNw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "331800de5053fcebacf6813adb5db9c9dca22a0c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,50 @@
+{
+  description = "container-magic: rapidly create containerised development environments";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  inputs.flake-utils.url = "github:numtide/flake-utils";
+
+  outputs =
+    { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+        # Track the version published by semantic-release rather than duplicating it.
+        version = (builtins.fromTOML (builtins.readFile ./pyproject.toml)).project.version;
+      in
+      {
+        packages.default = pkgs.python3Packages.buildPythonApplication {
+          pname = "container-magic";
+          inherit version;
+          src = self;
+          pyproject = true;
+
+          build-system = [ pkgs.python3Packages.setuptools ];
+
+          dependencies = with pkgs.python3Packages; [
+            pyyaml
+            jinja2
+            click
+            pydantic
+            requests
+          ];
+
+          # cm shells out to a container runtime (podman/docker) found in PATH at
+          # run time; it deliberately isn't bundled, so the consumer provides it.
+          # cm's own test suite needs that runtime, which the Nix sandbox lacks.
+          doCheck = false;
+        };
+
+        apps.default = {
+          type = "app";
+          program = "${self.packages.${system}.default}/bin/cm";
+        };
+      }
+    )
+    // {
+      overlays.default = final: prev: {
+        container-magic = self.packages.${final.system}.default;
+      };
+    };
+}


### PR DESCRIPTION
Adds a `flake.nix` (and pinned `flake.lock`) so container-magic can be consumed
on Nix:

- `nix run github:markhedleyjones/container-magic -- ...`
- `nix profile install github:markhedleyjones/container-magic`
- as a flake input + `overlays.default` for declarative use (e.g. NixOS hosts)

It wraps the existing setuptools package with `buildPythonApplication`
(`packages.default` / `apps.default` = the `cm` CLI). The version is read from
`pyproject.toml` so it tracks semantic-release bumps automatically.
`doCheck = false` because cm's own suite needs a container runtime the Nix
sandbox doesn't have, and no podman/docker is bundled - cm resolves the runtime
from `PATH` at run time, preserving the existing auto-detect.

Validated locally with `nix build`: the built `cm --version` reports 5.4.2 and
the package ships all seven `registry/*.yaml` files (depends on the package-data
fix in #66 - without it a nix build would produce a registry-less `cm`).

Typed `build:` so it doesn't trigger a version bump - the published Python
package is unchanged; this only adds repository packaging.