### PR TITLE
docs: fix audit findings across docs and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,15 @@ cm build
 cm run python --version
 ```
 
+On Nix, run it without installing - or add it as a flake input:
+
+```bash
+nix run github:markhedleyjones/container-magic -- init python:3.11 my-project
+nix profile install github:markhedleyjones/container-magic   # install cm
+```
+
+The flake exposes `packages.default` / `apps.default` (the `cm` CLI) and an `overlays.default` for declarative setups.
+
 A minimal `cm.yaml`:
 
 ```yaml

--- a/docs/build-steps.md
+++ b/docs/build-steps.md
@@ -198,7 +198,7 @@ Any string that doesn't match a built-in keyword is treated as a custom Dockerfi
 
 ### Implicit RUN Wrapping
 
-If a step starts with an **uppercase Dockerfile instruction** (`RUN`, `ENV`, `COPY`, `WORKDIR`, `ADD`, `EXPOSE`, `LABEL`, `USER`, `VOLUME`), it passes through to the Dockerfile as-is. Otherwise, container-magic automatically wraps the step with `RUN`:
+If a step starts with an **uppercase Dockerfile instruction** (`ADD`, `ARG`, `CMD`, `COPY`, `ENTRYPOINT`, `ENV`, `EXPOSE`, `FROM`, `HEALTHCHECK`, `LABEL`, `RUN`, `SHELL`, `STOPSIGNAL`, `USER`, `VOLUME`, `WORKDIR`), it passes through to the Dockerfile as-is. Otherwise, container-magic automatically wraps the step with `RUN`:
 
 ```yaml
 steps:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -362,6 +362,12 @@ commands:
 | `ipc` | IPC namespace mode override for this command (e.g. `host`, `shareable`) |
 | `mounts` | Named bind mounts (see [Mounts](mounts.md)) |
 
+Commands run through a shell with `set -o pipefail` enabled, so a failing
+element of a pipeline (e.g. `pytest | tee test.log`) propagates its non-zero
+exit code instead of being masked by the last command - useful when a command's
+exit status gates something (CI, `&&` chains). On shells without the option
+(POSIX `dash`) this degrades to standard last-command behaviour.
+
 **Development:**
 
 - `cm run train` - from anywhere in your repository
@@ -419,6 +425,17 @@ The standalone `build.sh` script builds the production target by default:
 ./build.sh --tag v1.0   # Builds production stage, tagged as 'v1.0'
 ./build.sh --help       # Shows available options
 ```
+
+The default stage is `production`. To make `build.sh` build a different stage,
+set `build_script.default_target` (it must name a stage in your config):
+
+```yaml
+build_script:
+  default_target: release
+```
+
+This only affects the standalone `build.sh`; `cm build [target]` takes the
+stage as an argument and ignores it.
 
 **Options:**
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -6,6 +6,21 @@
 pip install container-magic
 ```
 
+### Nix
+
+container-magic ships a flake, so Nix users can run it without installing,
+install it into a profile, or consume it declaratively:
+
+```bash
+nix run github:markhedleyjones/container-magic -- init python:3.11 my-project
+nix profile install github:markhedleyjones/container-magic   # installs `cm`
+```
+
+As a flake input, `packages.default` / `apps.default` provide the `cm` CLI and
+`overlays.default` adds `container-magic` to your package set (e.g. on NixOS).
+A container runtime (Docker or Podman) is still resolved from `PATH` at run
+time - the flake deliberately doesn't bundle one.
+
 ## Create a Project
 
 ```bash

--- a/docs/mounts.md
+++ b/docs/mounts.md
@@ -83,7 +83,7 @@ three.
 ### Container paths
 
 - `ro` mounts: `/mnt/<name>/<basename>` - preserves the original filename
-- `rw` mounts: `/mnt/<name>/` - the directory itself
+- `rw` mounts: `/mnt/<name>` - the directory itself
 
 A manifest file at `/run/cm/mounts` records the host-to-container path mappings
 for any active mounts.
@@ -137,7 +137,8 @@ commands:
 
 ```bash
 cm run latest recordings=/data/recordings
-# The script finds the newest file in /mnt/recordings/ itself
+# --dir resolves to /mnt/recordings/recordings (ro mount = /mnt/<name>/<basename>);
+# the script searches there for the newest file
 ```
 
 The mount doesn't have to point to a specific file - it can be any level of the

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -129,3 +129,30 @@ steps:
 ```
 
 See [User Handling](user-handling.md) for more on copy ownership.
+
+## Rootless Podman: build fails on the first `RUN` (cgroup / sd-bus)
+
+When container-magic runs as a **session-less user** - a CI runner, a systemd
+service, or a non-login system account - a rootless Podman build can die on the
+first `RUN` layer with an error like:
+
+```
+crun: ... sd-bus call: Permission denied
+```
+
+Podman often prints a warning first (`no systemd user session available,
+falling back to --cgroup-manager=cgroupfs`), but that fallback only covers
+Podman's own driver - the OCI runtime (`crun`) still attempts the systemd
+sd-bus call on the `RUN` layer unless told otherwise.
+
+**Fix** - select a session-free cgroup manager and event logger in
+`containers.conf` (e.g. `~/.config/containers/containers.conf`):
+
+```toml
+[engine]
+cgroup_manager = "cgroupfs"
+events_logger = "file"
+```
+
+A login user with a running systemd session doesn't hit this; it's specific to
+headless / non-login execution.

--- a/docs/user-handling.md
+++ b/docs/user-handling.md
@@ -103,7 +103,7 @@ stages:
       - copy: app.conf /home/nonroot/.config/      # User-owned (become active)
 ```
 
-See [Build Steps](build-steps.md#4-copy) for full details on the copy step.
+See [Build Steps](build-steps.md#2-copy) for full details on the copy step.
 
 ## Explicit User Steps
 


### PR DESCRIPTION
Fixes from a full documentation audit (every finding verified against the code; `mkdocs build --strict` passes).

- **mounts**: the discovery-pattern example documented the container path as `/mnt/recordings/`, but read-only mounts resolve to `/mnt/<name>/<basename>` (so `/mnt/recordings/recordings`); corrected, and dropped the `rw`-mount trailing slash to match the generated paths (`runner.py`).
- **user-handling**: fixed a broken anchor - the copy-step link pointed at `#4-copy` (section 4 is `env`); it's `#2-copy`.
- **build-steps**: the implicit-`RUN`-wrapping list showed 9 of the 16 instructions that actually pass through (`steps.py` `_DOCKERFILE_INSTRUCTIONS`); added the missing ARG, CMD, ENTRYPOINT, FROM, HEALTHCHECK, SHELL, STOPSIGNAL.
- **configuration**: documented that custom commands run with `set -o pipefail` (so a failing pipeline element propagates its exit code - matters for gating), and the `build_script.default_target` field.
- **README + getting-started**: documented Nix install (`nix run` / `nix profile install` / flake input + `overlays.default`), which the flake added but the docs didn't mention.
- **troubleshooting**: added the rootless-Podman fix for session-less users (CI/systemd/non-login) where the build dies on the first `RUN` with a `crun` sd-bus error - set `cgroup_manager="cgroupfs"` + `events_logger="file"` in `containers.conf`.

Typed `docs:` so it triggers no release.