### PR TITLE
feat(build): support build-time secrets via BuildKit secret mounts

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -443,6 +443,42 @@ stage as an argument and ignores it.
 - `--uid UID` - override the user UID
 - `--gid GID` - override the user GID
 
+## Build Secrets
+
+Credentials a build step needs - a private package-index token, an SSH key, an
+`~/.aws/credentials` file - must not be baked into the image. Build args and
+environment variables are the wrong tool: they persist in the image layers and
+history. BuildKit secret mounts expose the value only for the duration of one
+`RUN` and leave nothing behind.
+
+Declare secrets under `build_secrets`, each with an `id` and exactly one source
+- a host file (`src`) or a host environment variable (`env`):
+
+```yaml
+build_secrets:
+  - id: pip_token        # from an environment variable
+    env: PIP_TOKEN
+  - id: aws              # from a host file (~ is expanded at build time)
+    src: ~/.aws/credentials
+```
+
+Mount a secret in the step that needs it with an uppercase `RUN` passthrough,
+reading it from `/run/secrets/<id>`:
+
+```yaml
+stages:
+  base:
+    from: python:3.11-slim
+    steps:
+      - RUN --mount=type=secret,id=pip_token \
+          pip install --index-url "https://$(cat /run/secrets/pip_token)@pypi.example.com/simple" mypkg
+```
+
+`cm build` and the generated `build.sh` both pass the matching `--secret`
+flags automatically. Secret mounts require BuildKit (the default builder in
+current Docker; supported by Podman). The secret value never appears in the
+final image.
+
 ## Build Context
 
 Container-magic manages `.dockerignore` with a deny-by-default policy. Only

--- a/src/container_magic/core/builder.py
+++ b/src/container_magic/core/builder.py
@@ -93,6 +93,14 @@ def build_container(
     build_args.extend(["--build-arg", f"USER_GID={user_gid}"])
     build_args.extend(["--build-arg", f"WORKSPACE_NAME={config.names.workspace}"])
 
+    # Build-time secrets (BuildKit). ~ is expanded for the local build.
+    for secret in config.build_secrets:
+        if secret.src:
+            src = os.path.expanduser(secret.src)
+            build_args.extend(["--secret", f"id={secret.id},src={src}"])
+        else:
+            build_args.extend(["--secret", f"id={secret.id},env={secret.env}"])
+
     if target == "development":
         # Development: also pass USER_HOME
         user_home = os.path.expanduser("~")

--- a/src/container_magic/core/config.py
+++ b/src/container_magic/core/config.py
@@ -375,6 +375,36 @@ class BuildScriptConfig(BaseModel):
     )
 
 
+class BuildSecretConfig(BaseModel):
+    """A build-time secret exposed to RUN steps via BuildKit secret mounts.
+
+    Steps consume it with ``RUN --mount=type=secret,id=<id> ...``; the build
+    invocation supplies the value with ``--secret``. Secrets are not persisted
+    in image layers, unlike build args or env vars.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str = Field(
+        description="Secret id, referenced as 'RUN --mount=type=secret,id=<id>'"
+    )
+    src: Optional[str] = Field(
+        default=None, description="Host file path providing the secret value"
+    )
+    env: Optional[str] = Field(
+        default=None,
+        description="Host environment variable name providing the secret value",
+    )
+
+    @model_validator(mode="after")
+    def require_single_source(self) -> "BuildSecretConfig":
+        if bool(self.src) == bool(self.env):
+            raise ValueError(
+                f"build secret '{self.id}' needs exactly one of 'src' or 'env'"
+            )
+        return self
+
+
 class ContainerMagicConfig(BaseModel):
     """Complete container-magic configuration."""
 
@@ -398,6 +428,10 @@ class ContainerMagicConfig(BaseModel):
         description="Per-project command registry overrides for structured step syntax",
     )
     build_script: BuildScriptConfig = Field(default_factory=BuildScriptConfig)
+    build_secrets: List[BuildSecretConfig] = Field(
+        default_factory=list,
+        description="Build-time secrets exposed to RUN steps via --mount=type=secret",
+    )
 
     def effective_runtime(self, stage_name: str) -> RuntimeConfig:
         """Resolve the effective runtime for a stage.
@@ -531,6 +565,8 @@ class ContainerMagicConfig(BaseModel):
         default_runtime = RuntimeConfig().model_dump(exclude_none=True)
         if runtime == {} or runtime == default_runtime:
             data.pop("runtime", None)
+        if not data.get("build_secrets"):
+            data.pop("build_secrets", None)
 
         # Custom YAML dumper that adds blank lines between top-level sections
         class BlankLineDumper(yaml.SafeDumper):

--- a/src/container_magic/generators/build_script.py
+++ b/src/container_magic/generators/build_script.py
@@ -40,6 +40,19 @@ def generate_build_script(
         workspace_path = project_dir / config.names.workspace
         workspace_symlinks = scan_workspace_symlinks(workspace_path)
 
+    # Build secret --secret arguments as a single bash array literal. A leading
+    # ~ becomes ${HOME} so the committed script stays portable across machines.
+    secret_specs = []
+    for secret in config.build_secrets:
+        if secret.src:
+            src = secret.src
+            if src == "~" or src.startswith("~/"):
+                src = "${HOME}" + src[1:]
+            secret_specs.append(f"id={secret.id},src={src}")
+        else:
+            secret_specs.append(f"id={secret.id},env={secret.env}")
+    secret_flags = " ".join(f"--secret {spec}" for spec in secret_specs)
+
     content = template.render(
         project_name=config.names.image,
         workspace_name=config.names.workspace,
@@ -50,6 +63,7 @@ def generate_build_script(
         production_user_home=production_user_home,
         backend=config.backend,
         workspace_symlinks=workspace_symlinks,
+        secret_flags=secret_flags,
     )
 
     build_script = project_dir / "build.sh"

--- a/src/container_magic/templates/build.sh.j2
+++ b/src/container_magic/templates/build.sh.j2
@@ -77,12 +77,16 @@ mkdir -p "${STAGING_DIR}/$(dirname "{{ rel_path }}")"
 cp -rL "{{ workspace_name }}/{{ rel_path }}" "${STAGING_DIR}/{{ rel_path }}"
 {% endfor %}
 {%- endif %}
+# Build-time secrets (BuildKit). Empty unless build_secrets is configured.
+SECRET_ARGS=({{ secret_flags }})
+
 ${RUNTIME} build \
 	--target "${TARGET}" \
 	--build-arg USER_NAME="${USER_NAME}" \
 	--build-arg USER_UID="${USER_UID}" \
 	--build-arg USER_GID="${USER_GID}" \
 	--build-arg WORKSPACE_NAME="${WORKSPACE_NAME}" \
+	${SECRET_ARGS[@]+"${SECRET_ARGS[@]}"} \
 	--tag "${IMAGE_NAME}:${TAG}" \
 	.
 

--- a/tests/unit/test_build_secrets.py
+++ b/tests/unit/test_build_secrets.py
@@ -1,0 +1,84 @@
+"""Tests for build-time secrets (BuildKit --mount=type=secret)."""
+
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import pytest
+from pydantic import ValidationError
+
+from container_magic.core.config import ContainerMagicConfig
+from container_magic.generators.build_script import generate_build_script
+
+
+def _config(**extra):
+    return {
+        "names": {"image": "test", "user": "app"},
+        "stages": {
+            "base": {"from": "debian:bookworm-slim"},
+            "development": {"from": "base"},
+            "production": {"from": "base"},
+        },
+        **extra,
+    }
+
+
+def _build_sh(config_dict):
+    config = ContainerMagicConfig(**config_dict)
+    with TemporaryDirectory() as tmp:
+        project_dir = Path(tmp)
+        generate_build_script(config, project_dir)
+        return (project_dir / "build.sh").read_text()
+
+
+def test_build_secret_with_src_emits_secret_flag():
+    content = _build_sh(
+        _config(build_secrets=[{"id": "aws", "src": "~/.aws/credentials"}])
+    )
+    # ~ is rewritten to ${HOME} so the committed script stays portable.
+    assert "--secret id=aws,src=${HOME}/.aws/credentials" in content
+
+
+def test_build_secret_with_env_emits_secret_flag():
+    content = _build_sh(_config(build_secrets=[{"id": "tok", "env": "PIP_TOKEN"}]))
+    assert "--secret id=tok,env=PIP_TOKEN" in content
+
+
+def test_build_secret_absolute_src_unchanged():
+    content = _build_sh(_config(build_secrets=[{"id": "key", "src": "/run/keys/key"}]))
+    assert "--secret id=key,src=/run/keys/key" in content
+
+
+def test_no_build_secrets_emits_no_secret_flag():
+    content = _build_sh(_config())
+    assert "--secret" not in content
+
+
+def test_generated_build_sh_is_valid_bash_with_and_without_secrets():
+    import shutil
+    import subprocess
+
+    bash = shutil.which("bash")
+    if bash is None:  # pragma: no cover
+        pytest.skip("bash not available")
+    for secrets in ([], [{"id": "aws", "src": "~/.aws/credentials"}]):
+        with TemporaryDirectory() as tmp:
+            project_dir = Path(tmp)
+            config = ContainerMagicConfig(**_config(build_secrets=secrets))
+            generate_build_script(config, project_dir)
+            script = project_dir / "build.sh"
+            result = subprocess.run(
+                [bash, "-n", str(script)], capture_output=True, text=True
+            )
+            assert result.returncode == 0, result.stderr
+
+
+def test_build_secret_requires_a_source():
+    with pytest.raises(ValidationError, match="exactly one of"):
+        ContainerMagicConfig(**_config(build_secrets=[{"id": "aws"}]))
+
+
+def test_build_secret_rejects_two_sources():
+    with pytest.raises(ValidationError, match="exactly one of"):
+        ContainerMagicConfig(
+            **_config(build_secrets=[{"id": "aws", "src": "/x", "env": "Y"}])
+        )


### PR DESCRIPTION
Adds a `build_secrets` config block so credentials a build step needs (private
package-index tokens, SSH keys, `~/.aws/credentials`) can be passed without
baking them into image layers or history - which is what build args and env
vars do.

Each entry has an `id` and exactly one source: a host file (`src`, leading `~`
expanded to `${HOME}` in the committed script) or a host environment variable
(`env`):

```yaml
build_secrets:
  - id: pip_token
    env: PIP_TOKEN
  - id: aws
    src: ~/.aws/credentials
```

`cm build` and the generated `build.sh` pass the matching `--secret` flags
automatically; `build.sh` collects them into a `SECRET_ARGS` array expanded
with the empty-array-safe `${ARR[@]+...}` idiom (portable to old bash). Steps
consume a secret with an uppercase passthrough that cm already supports:

```yaml
- RUN --mount=type=secret,id=pip_token \
    pip install --index-url "https://$(cat /run/secrets/pip_token)@..." mypkg
```

Requires BuildKit (default in current Docker, supported by Podman). Additive
and opt-in - no behaviour change for existing configs.