### PR TITLE
feat(devcontainer): generate .devcontainer/devcontainer.json

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -479,6 +479,35 @@ flags automatically. Secret mounts require BuildKit (the default builder in
 current Docker; supported by Podman). The secret value never appears in the
 final image.
 
+## Dev Containers
+
+Set `devcontainer: true` to also generate `.devcontainer/devcontainer.json`, so
+the same image cm builds can be opened in VS Code, GitHub Codespaces, or any
+[Dev Container](https://containers.dev)-aware tool - the editor runs inside the
+container, complementing the terminal-based `cm run` workflow.
+
+```yaml
+devcontainer: true
+
+names:
+  image: my-project
+  user: nonroot
+```
+
+`cm update` (and `cm init`) then writes a `.devcontainer/devcontainer.json` that:
+
+- builds the `development` stage from the generated `Dockerfile`
+  (`build.dockerfile: ../Dockerfile`, `build.context: ..`)
+- bind-mounts the workspace directory to its in-container path, matching cm's
+  development mount (`workspaceMount` / `workspaceFolder`)
+- sets `remoteUser` to `names.user` with `updateRemoteUserUID: true`, so the
+  container user's UID/GID is remapped to your host user - the same
+  file-ownership fix cm applies for `cm run`
+- forwards any ports declared on custom `commands`
+
+The file is a generated, committed artefact like the Dockerfile and scripts;
+commit it and regenerate with `cm update`.
+
 ## Build Context
 
 Container-magic manages `.dockerignore` with a deny-by-default policy. Only

--- a/src/container_magic/cli/main.py
+++ b/src/container_magic/cli/main.py
@@ -10,6 +10,7 @@ import click
 from container_magic import __version__
 from container_magic.core.config import ContainerMagicConfig, find_config_file
 from container_magic.generators.build_script import generate_build_script
+from container_magic.generators.devcontainer import generate_devcontainer
 from container_magic.generators.dockerfile import generate_dockerfile
 from container_magic.generators.run_script import generate_run_script
 
@@ -210,6 +211,7 @@ def init(
     )
     generate_build_script(config, path, workspace_symlinks=workspace_symlinks)
     generate_run_script(config, path)
+    generate_devcontainer(config, path)
 
     # Update ignore files
     update_gitignore(path)
@@ -259,6 +261,7 @@ def update(path: Path):
     )
     generate_build_script(config, path, workspace_symlinks=workspace_symlinks)
     generate_run_script(config, path)
+    generate_devcontainer(config, path)
 
     # Update ignore files
     update_gitignore(path)

--- a/src/container_magic/core/config.py
+++ b/src/container_magic/core/config.py
@@ -432,6 +432,10 @@ class ContainerMagicConfig(BaseModel):
         default_factory=list,
         description="Build-time secrets exposed to RUN steps via --mount=type=secret",
     )
+    devcontainer: bool = Field(
+        default=False,
+        description="Generate .devcontainer/devcontainer.json for IDE / Codespaces use",
+    )
 
     def effective_runtime(self, stage_name: str) -> RuntimeConfig:
         """Resolve the effective runtime for a stage.
@@ -567,6 +571,8 @@ class ContainerMagicConfig(BaseModel):
             data.pop("runtime", None)
         if not data.get("build_secrets"):
             data.pop("build_secrets", None)
+        if not data.get("devcontainer"):
+            data.pop("devcontainer", None)
 
         # Custom YAML dumper that adds blank lines between top-level sections
         class BlankLineDumper(yaml.SafeDumper):

--- a/src/container_magic/generators/devcontainer.py
+++ b/src/container_magic/generators/devcontainer.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Generate .devcontainer/devcontainer.json for IDE / Codespaces interop.
+
+Maps the relevant parts of cm.yaml onto the Dev Container specification so the
+same image cm builds can be opened in VS Code, GitHub Codespaces, or any
+devcontainer-aware tool. Only written when `devcontainer: true` is set.
+"""
+
+import json
+from pathlib import Path
+
+from container_magic.core.config import ContainerMagicConfig
+
+
+def _forward_ports(config: ContainerMagicConfig) -> list:
+    """Collect host ports from custom-command `ports` declarations, in order."""
+    ports: list = []
+    for command in config.commands.values():
+        for spec in command.ports:
+            host = str(spec).split(":")[0].strip()
+            if host.isdigit():
+                port = int(host)
+                if port not in ports:
+                    ports.append(port)
+    return ports
+
+
+def generate_devcontainer(config: ContainerMagicConfig, project_dir: Path) -> None:
+    """Write .devcontainer/devcontainer.json when enabled in the config."""
+    if not config.devcontainer:
+        return
+
+    user = config.names.user
+    has_user = user != "root"
+    home = f"/home/{user}" if has_user else "/root"
+    workspace = config.names.workspace
+    container_workspace = f"{home}/{workspace}"
+
+    devcontainer = {
+        "name": config.names.image,
+        "build": {
+            "dockerfile": "../Dockerfile",
+            "context": "..",
+            "target": "development",
+            "args": {
+                "USER_NAME": user,
+                "WORKSPACE_NAME": workspace,
+                "USER_HOME": home,
+            },
+        },
+        # Bind only the workspace directory, mirroring cm's development mount.
+        "workspaceFolder": container_workspace,
+        "workspaceMount": (
+            f"source=${{localWorkspaceFolder}}/{workspace},"
+            f"target={container_workspace},type=bind"
+        ),
+        "remoteUser": user,
+    }
+
+    # updateRemoteUserUID remaps the container user's UID/GID to the host
+    # user's at runtime - the host-identity matching cm does for `cm run`.
+    if has_user:
+        devcontainer["updateRemoteUserUID"] = True
+
+    ports = _forward_ports(config)
+    if ports:
+        devcontainer["forwardPorts"] = ports
+
+    out_dir = project_dir / ".devcontainer"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    (out_dir / "devcontainer.json").write_text(
+        json.dumps(devcontainer, indent=2) + "\n"
+    )

--- a/tests/unit/test_devcontainer.py
+++ b/tests/unit/test_devcontainer.py
@@ -1,0 +1,99 @@
+"""Tests for devcontainer.json generation."""
+
+import json
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from container_magic.core.config import ContainerMagicConfig
+from container_magic.generators.devcontainer import generate_devcontainer
+
+
+def _config(**extra):
+    return {
+        "names": {"image": "demo", "workspace": "workspace", "user": "app"},
+        "stages": {
+            "base": {"from": "python:3.11-slim"},
+            "development": {"from": "base"},
+            "production": {"from": "base"},
+        },
+        **extra,
+    }
+
+
+def _generate(config_dict):
+    config = ContainerMagicConfig(**config_dict)
+    with TemporaryDirectory() as tmp:
+        project_dir = Path(tmp)
+        generate_devcontainer(config, project_dir)
+        path = project_dir / ".devcontainer" / "devcontainer.json"
+        return json.loads(path.read_text()) if path.exists() else None
+
+
+def test_not_generated_by_default():
+    assert _generate(_config()) is None
+
+
+def test_generated_when_enabled():
+    dc = _generate(_config(devcontainer=True))
+    assert dc is not None
+    assert dc["name"] == "demo"
+    assert dc["build"]["dockerfile"] == "../Dockerfile"
+    assert dc["build"]["context"] == ".."
+    assert dc["build"]["target"] == "development"
+    assert dc["build"]["args"]["USER_NAME"] == "app"
+    assert dc["build"]["args"]["WORKSPACE_NAME"] == "workspace"
+
+
+def test_workspace_mount_and_folder():
+    dc = _generate(_config(devcontainer=True))
+    assert dc["workspaceFolder"] == "/home/app/workspace"
+    assert (
+        dc["workspaceMount"]
+        == "source=${localWorkspaceFolder}/workspace,target=/home/app/workspace,type=bind"
+    )
+
+
+def test_remote_user_and_uid_update_for_non_root():
+    dc = _generate(_config(devcontainer=True))
+    assert dc["remoteUser"] == "app"
+    assert dc["updateRemoteUserUID"] is True
+
+
+def test_root_user_has_no_uid_update():
+    config = {
+        "names": {"image": "demo", "workspace": "ws", "user": "root"},
+        "stages": {
+            "base": {"from": "python:3.11-slim"},
+            "development": {"from": "base"},
+            "production": {"from": "base"},
+        },
+        "devcontainer": True,
+    }
+    dc = _generate(config)
+    assert dc["remoteUser"] == "root"
+    assert "updateRemoteUserUID" not in dc
+    assert dc["workspaceFolder"] == "/root/ws"
+
+
+def test_forward_ports_from_commands():
+    dc = _generate(
+        _config(
+            devcontainer=True,
+            commands={
+                "serve": {
+                    "command": "python -m http.server 8000",
+                    "ports": ["8000:8000"],
+                },
+                "api": {
+                    "command": "uvicorn app:app",
+                    "ports": ["9000:9000", "9001:9001"],
+                },
+            },
+        )
+    )
+    assert dc["forwardPorts"] == [8000, 9000, 9001]
+
+
+def test_no_forward_ports_key_when_no_command_ports():
+    dc = _generate(_config(devcontainer=True))
+    assert "forwardPorts" not in dc


### PR DESCRIPTION
Set `devcontainer: true` and cm generates a Dev Container manifest from the
same `cm.yaml`, so the image cm builds opens directly in VS Code, GitHub
Codespaces, or any [devcontainer](https://containers.dev)-aware tool - the
IDE-in-container workflow alongside the existing terminal `cm run` flow. This
is the interop standard the ecosystem (incl. ROS) already speaks, so it turns
a competing format into a free export target.

The generated `.devcontainer/devcontainer.json`:

- builds the `development` stage from the committed Dockerfile
  (`build.dockerfile: ../Dockerfile`, `build.context: ..`, `build.target`,
  `build.args`)
- bind-mounts the workspace dir to its in-container path
  (`workspaceMount`/`workspaceFolder`), mirroring cm's development mount
- sets `remoteUser` to `names.user` with `updateRemoteUserUID: true`, so the
  container user's UID/GID is remapped to the host user - the same
  file-ownership fix cm applies for `cm run`
- forwards ports declared on custom `commands`

Written by `cm init`/`cm update` as a committed artefact like the Dockerfile.
Opt-in, off by default - no new file unless you ask for it. Mapping verified
against the containers.dev spec. v1 covers build + workspace + user + ports;
advanced runtime (GPU/display runArgs) is a deliberate follow-up.