### PR TITLE
feat(dockerfile): optionally pin base images to their digest

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -508,6 +508,28 @@ names:
 The file is a generated, committed artefact like the Dockerfile and scripts;
 commit it and regenerate with `cm update`.
 
+## Pinning Base Images
+
+Set `pin_base_images: true` to resolve each external base image to its digest
+at generation time, so the Dockerfile pins `FROM image:tag@sha256:...`. A tag
+like `python:3.11-slim` can change underneath you; pinning the digest makes
+rebuilds reproducible.
+
+```yaml
+pin_base_images: true
+
+stages:
+  base:
+    from: python:3.11-slim   # becomes FROM python:3.11-slim@sha256:... AS base
+```
+
+Only external images are pinned; `from:` references to other stages are left
+alone. Resolution is best-effort and runs `cm update`/`cm build` against the
+registry (via `skopeo` or `docker buildx imagetools`); if a digest can't be
+resolved - offline, missing tooling, private registry - cm prints a warning and
+leaves that image on its tag rather than failing. Re-run `cm update` to refresh
+the pins when you want to move to a newer base image.
+
 ## Build Context
 
 Container-magic manages `.dockerignore` with a deny-by-default policy. Only

--- a/src/container_magic/core/config.py
+++ b/src/container_magic/core/config.py
@@ -436,6 +436,10 @@ class ContainerMagicConfig(BaseModel):
         default=False,
         description="Generate .devcontainer/devcontainer.json for IDE / Codespaces use",
     )
+    pin_base_images: bool = Field(
+        default=False,
+        description="Resolve external base images to their digest (FROM image@sha256:...) for reproducible builds",
+    )
 
     def effective_runtime(self, stage_name: str) -> RuntimeConfig:
         """Resolve the effective runtime for a stage.
@@ -573,6 +577,8 @@ class ContainerMagicConfig(BaseModel):
             data.pop("build_secrets", None)
         if not data.get("devcontainer"):
             data.pop("devcontainer", None)
+        if not data.get("pin_base_images"):
+            data.pop("pin_base_images", None)
 
         # Custom YAML dumper that adds blank lines between top-level sections
         class BlankLineDumper(yaml.SafeDumper):

--- a/src/container_magic/core/digest.py
+++ b/src/container_magic/core/digest.py
@@ -1,0 +1,54 @@
+"""Resolve a container image reference to its registry digest (best-effort).
+
+Used for optional base-image pinning. Network-dependent and best-effort: any
+failure (tool missing, offline, auth, timeout, unexpected output) returns None
+so the caller falls back to the unpinned tag rather than breaking generation.
+"""
+
+import shutil
+import subprocess
+from typing import List, Optional
+
+_TIMEOUT_SECONDS = 30
+
+
+def _run(cmd: List[str]) -> Optional[str]:
+    try:
+        result = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=_TIMEOUT_SECONDS
+        )
+    except (subprocess.SubprocessError, OSError):
+        return None
+    if result.returncode != 0:
+        return None
+    digest = result.stdout.strip()
+    return digest if digest.startswith("sha256:") else None
+
+
+def resolve_image_digest(ref: str) -> Optional[str]:
+    """Return the ``sha256:...`` digest for an image ref, or None if unresolved.
+
+    Tries ``skopeo`` (works for any registry without pulling), then
+    ``docker buildx imagetools``. Returns None on any failure.
+    """
+    if shutil.which("skopeo"):
+        digest = _run(
+            ["skopeo", "inspect", f"docker://{ref}", "--format", "{{.Digest}}"]
+        )
+        if digest:
+            return digest
+    if shutil.which("docker"):
+        digest = _run(
+            [
+                "docker",
+                "buildx",
+                "imagetools",
+                "inspect",
+                ref,
+                "--format",
+                "{{.Manifest.Digest}}",
+            ]
+        )
+        if digest:
+            return digest
+    return None

--- a/src/container_magic/generators/dockerfile.py
+++ b/src/container_magic/generators/dockerfile.py
@@ -1,11 +1,13 @@
 """Dockerfile generation from configuration."""
 
+import sys
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
 from jinja2 import Environment, PackageLoader, select_autoescape
 
 from container_magic.core.cache import build_asset_map
+from container_magic.core.digest import resolve_image_digest
 from container_magic.core.config import (
     ContainerMagicConfig,
     StageConfig,
@@ -415,10 +417,27 @@ def generate_dockerfile(
     stages_data = []
     pip_prepared_state: Dict[str, bool] = {}
     user_created_state: Dict[str, bool] = {}
+    digest_cache: Dict[str, Optional[str]] = {}
     for stage_name, stage_config in stages.items():
         base_image = stage_config.frm
         resolved_image = resolve_base_image(base_image, stages)
         from_is_image = ":" in base_image or "/" in base_image
+
+        # Optionally pin external base images to their digest for reproducible
+        # builds. Best-effort: fall back to the tag if it can't be resolved.
+        from_value = base_image
+        if config.pin_base_images and from_is_image:
+            if base_image not in digest_cache:
+                digest_cache[base_image] = resolve_image_digest(base_image)
+            digest = digest_cache[base_image]
+            if digest:
+                from_value = f"{base_image}@{digest}"
+            else:
+                print(
+                    f"Warning: could not resolve a digest for '{base_image}'; "
+                    "leaving it unpinned.",
+                    file=sys.stderr,
+                )
 
         # Resolve distro: explicit on this stage, or inherited from parent chain
         effective_distro = resolve_inherited_distro(stage_name, stages)
@@ -520,7 +539,7 @@ def generate_dockerfile(
         stages_data.append(
             {
                 "name": stage_name,
-                "from": base_image,
+                "from": from_value,
                 "from_is_image": from_is_image,
                 "package_manager": package_manager,
                 "user_creation_style": user_creation_style,

--- a/tests/unit/test_pin_base_images.py
+++ b/tests/unit/test_pin_base_images.py
@@ -1,0 +1,81 @@
+"""Tests for optional base-image digest pinning."""
+
+import container_magic.generators.dockerfile as dockerfile_mod
+from container_magic.core import digest as digest_mod
+from tests.unit.conftest import generate_dockerfile_from_dict as _generate
+
+
+def _config(**extra):
+    return {
+        "names": {"image": "test", "user": "app"},
+        "stages": {
+            "base": {"from": "debian:bookworm-slim"},
+            "development": {"from": "base"},
+            "production": {"from": "base"},
+        },
+        **extra,
+    }
+
+
+def test_not_pinned_by_default(monkeypatch):
+    monkeypatch.setattr(dockerfile_mod, "resolve_image_digest", lambda ref: "sha256:x")
+    content = _generate(_config())
+    assert "FROM debian:bookworm-slim AS base" in content
+    assert "@sha256" not in content
+
+
+def test_resolver_not_called_when_disabled(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        dockerfile_mod,
+        "resolve_image_digest",
+        lambda ref: calls.append(ref) or "sha256:x",
+    )
+    _generate(_config())
+    assert calls == []
+
+
+def test_pinned_when_enabled(monkeypatch):
+    monkeypatch.setattr(
+        dockerfile_mod, "resolve_image_digest", lambda ref: "sha256:deadbeef"
+    )
+    content = _generate(_config(pin_base_images=True))
+    assert "FROM debian:bookworm-slim@sha256:deadbeef AS base" in content
+
+
+def test_stage_references_not_pinned(monkeypatch):
+    monkeypatch.setattr(
+        dockerfile_mod, "resolve_image_digest", lambda ref: "sha256:deadbeef"
+    )
+    content = _generate(_config(pin_base_images=True))
+    # development/production build FROM the 'base' stage, not an external image.
+    assert "FROM base AS development" in content
+    assert "FROM base AS production" in content
+
+
+def test_unresolvable_falls_back_to_tag(monkeypatch, capsys):
+    monkeypatch.setattr(dockerfile_mod, "resolve_image_digest", lambda ref: None)
+    content = _generate(_config(pin_base_images=True))
+    assert "FROM debian:bookworm-slim AS base" in content
+    assert "@sha256" not in content
+    assert "could not resolve a digest" in capsys.readouterr().err
+
+
+# --- resolver unit tests (no network) ---
+
+
+def test_run_returns_digest_on_clean_output():
+    assert digest_mod._run(["echo", "sha256:abc123"]) == "sha256:abc123"
+
+
+def test_run_rejects_non_digest_output():
+    assert digest_mod._run(["echo", "not-a-digest"]) is None
+
+
+def test_run_returns_none_on_failure():
+    assert digest_mod._run(["false"]) is None
+
+
+def test_resolve_returns_none_when_no_tools(monkeypatch):
+    monkeypatch.setattr(digest_mod.shutil, "which", lambda name: None)
+    assert digest_mod.resolve_image_digest("debian:bookworm-slim") is None


### PR DESCRIPTION
Set `pin_base_images: true` and cm resolves each external base image to its
registry digest at generation time, pinning `FROM image:tag@sha256:...` for
reproducible rebuilds (a moving tag like `python:3.11-slim` can change
underneath you). `from:` references to other stages are left untouched.

```yaml
pin_base_images: true
stages:
  base:
    from: python:3.11-slim   # -> FROM python:3.11-slim@sha256:... AS base
```

Resolution is best-effort and runs during `cm update`/`cm build` via `skopeo`
(or `docker buildx imagetools`). If a digest can't be resolved - offline,
missing tooling, private registry - cm prints a warning and leaves the image
on its tag rather than failing, so the feature degrades gracefully and never
breaks generation. Re-run `cm update` to refresh pins to a newer base.

Additive and opt-in (off by default). Generation logic is unit-tested with a
mocked resolver; the resolver helper has its own no-network unit tests.