### PR TITLE
feat(build): opt-in BuildKit cache mounts for package-manager steps

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -530,6 +530,35 @@ resolved - offline, missing tooling, private registry - cm prints a warning and
 leaves that image on its tag rather than failing. Re-run `cm update` to refresh
 the pins when you want to move to a newer base image.
 
+## Cache Mounts
+
+Set `cache_mounts: true` to add [BuildKit cache mounts](https://docs.docker.com/build/cache/optimize/#use-cache-mounts)
+to supported package-manager steps, so the package cache persists between
+builds without bloating the image - rebuilds after a small change re-use the
+downloaded packages instead of fetching them again.
+
+```yaml
+cache_mounts: true
+
+stages:
+  base:
+    from: debian:bookworm-slim
+    steps:
+      - apt-get:
+          install:
+            - build-essential
+```
+
+For `apt-get` this mounts caches at `/var/cache/apt` and `/var/lib/apt`,
+removes the base image's `docker-clean` (so downloaded `.deb` files are kept),
+and skips the apt-list cleanup (the lists now live in the cache mount, not the
+image layer). The cache lives in the BuildKit cache, not the final image, so
+image size is unaffected.
+
+Currently applies to `apt-get`; other package managers (pip, apk, dnf) are not
+yet cached. Requires BuildKit (the default builder in current Docker; supported
+by Podman) and is opt-in - off by default.
+
 ## Build Context
 
 Container-magic manages `.dockerignore` with a deny-by-default policy. Only

--- a/src/container_magic/core/config.py
+++ b/src/container_magic/core/config.py
@@ -440,6 +440,10 @@ class ContainerMagicConfig(BaseModel):
         default=False,
         description="Resolve external base images to their digest (FROM image@sha256:...) for reproducible builds",
     )
+    cache_mounts: bool = Field(
+        default=False,
+        description="Add BuildKit cache mounts to supported package-manager steps to speed rebuilds",
+    )
 
     def effective_runtime(self, stage_name: str) -> RuntimeConfig:
         """Resolve the effective runtime for a stage.
@@ -579,6 +583,8 @@ class ContainerMagicConfig(BaseModel):
             data.pop("devcontainer", None)
         if not data.get("pin_base_images"):
             data.pop("pin_base_images", None)
+        if not data.get("cache_mounts"):
+            data.pop("cache_mounts", None)
 
         # Custom YAML dumper that adds blank lines between top-level sections
         class BlankLineDumper(yaml.SafeDumper):

--- a/src/container_magic/core/registry.py
+++ b/src/container_magic/core/registry.py
@@ -53,12 +53,16 @@ class RegistryEntry:
         cleanup: str = "",
         fields: Optional[Dict[str, FieldSpec]] = None,
         installs_python_packages: bool = False,
+        cache: Optional[Dict[str, Any]] = None,
     ):
         self.setup = setup
         self.flags = flags
         self.cleanup = cleanup
         self.fields = fields or {}
         self.installs_python_packages = installs_python_packages
+        # Optional BuildKit cache-mount config, applied only when the user
+        # opts in. Shape: {targets: [str], setup: str, drop_cleanup: bool}.
+        self.cache = cache or {}
 
     def __repr__(self):
         return (
@@ -97,6 +101,7 @@ def _entry_from_data(entry_data: Dict[str, Any]) -> RegistryEntry:
         installs_python_packages=bool(
             entry_data.get("installs_python_packages", False)
         ),
+        cache=entry_data.get("cache"),
     )
 
 

--- a/src/container_magic/core/steps.py
+++ b/src/container_magic/core/steps.py
@@ -122,12 +122,18 @@ def build_command(
     body: Any,
     registry_entry: Optional[RegistryEntry] = None,
     field_values: Optional[Dict[str, Any]] = None,
+    cache_mounts: bool = False,
 ) -> str:
     """Build a complete RUN command from a tool name and its body.
 
     Flattens the dict structure into a command, injects registry flags
     after the subcommand, expands any field values declared by the registry
     entry, and appends cleanup if present.
+
+    When *cache_mounts* is set and the registry entry declares a ``cache``
+    block, the command is prefixed with BuildKit cache mounts, an extra setup
+    step is prepended (e.g. removing apt's docker-clean so debs persist), and
+    the cleanup is dropped if the cache block sets ``drop_cleanup``.
     """
     segments = [tool]
 
@@ -170,10 +176,21 @@ def build_command(
             command = " ".join(segments)
         else:
             command = " ".join(segments)
-        if registry_entry.setup:
-            command = f"{registry_entry.setup} && \\\n    {command}"
-        if registry_entry.cleanup:
+        cache = registry_entry.cache if cache_mounts else {}
+
+        setup = registry_entry.setup
+        if cache.get("setup"):
+            setup = f"{cache['setup']} && {setup}" if setup else cache["setup"]
+        if setup:
+            command = f"{setup} && \\\n    {command}"
+        if registry_entry.cleanup and not cache.get("drop_cleanup"):
             command = f"{command} && \\\n    {registry_entry.cleanup}"
+        if cache.get("targets"):
+            mounts = " ".join(
+                f"--mount=type=cache,target={target},sharing=locked"
+                for target in cache["targets"]
+            )
+            command = f"{mounts} {command}"
         return command
 
     # No registry entry or complex body - just flatten
@@ -236,6 +253,7 @@ def classify_bare_string(step: str) -> Dict[str, Any]:
 def parse_dict_step(
     step: Dict[str, Any],
     registry: Dict,
+    cache_mounts: bool = False,
 ) -> Dict[str, Any]:
     """Parse a dict step into a processed step dict.
 
@@ -342,19 +360,20 @@ def parse_dict_step(
             # No registry entry for the subcommand - pass through as-is
             body = value
 
-    command = build_command(key, body, entry, field_values)
+    command = build_command(key, body, entry, field_values, cache_mounts=cache_mounts)
     return {"type": "run", "command": command}
 
 
 def parse_step(
     step: Union[str, Dict[str, Any]],
     registry: Dict,
+    cache_mounts: bool = False,
 ) -> Dict[str, Any]:
     """Parse a single step (string or dict) into a processed step dict."""
     if isinstance(step, str):
         return classify_bare_string(step)
     elif isinstance(step, dict):
-        return parse_dict_step(step, registry)
+        return parse_dict_step(step, registry, cache_mounts=cache_mounts)
     else:
         raise ValueError(f"Step must be a string or dict, got {type(step).__name__}")
 

--- a/src/container_magic/generators/dockerfile.py
+++ b/src/container_magic/generators/dockerfile.py
@@ -219,6 +219,7 @@ def process_stage_steps(
     workspace_symlinks: List[tuple] = None,
     pip_prepared: bool = False,
     implicit_user: bool = False,
+    cache_mounts: bool = False,
 ) -> tuple:
     """Process build steps for a stage.
 
@@ -286,7 +287,7 @@ def process_stage_steps(
                 ordered_steps.append(prepare_step)
                 pip_prepared = True
 
-        parsed = parse_step(step, registry)
+        parsed = parse_step(step, registry, cache_mounts=cache_mounts)
 
         step_type = parsed["type"]
 
@@ -473,6 +474,7 @@ def generate_dockerfile(
             workspace_symlinks,
             pip_prepared=inherited_pip_prepared,
             implicit_user=implicit_user,
+            cache_mounts=config.cache_mounts,
         )
         pip_prepared_state[stage_name] = pip_prepared
 

--- a/src/container_magic/registry/apt-get.yaml
+++ b/src/container_magic/registry/apt-get.yaml
@@ -2,3 +2,9 @@ install:
   setup: "apt-get update"
   flags: "-y --no-install-recommends"
   cleanup: "rm -rf /var/lib/apt/lists/*"
+  cache:
+    targets:
+      - /var/cache/apt
+      - /var/lib/apt
+    setup: "rm -f /etc/apt/apt.conf.d/docker-clean"
+    drop_cleanup: true

--- a/tests/unit/test_cache_mounts.py
+++ b/tests/unit/test_cache_mounts.py
@@ -1,0 +1,56 @@
+"""Tests for opt-in BuildKit cache mounts on package-manager steps."""
+
+from tests.unit.conftest import generate_dockerfile_from_dict as _generate
+
+
+def _config(steps, **extra):
+    return {
+        "names": {"image": "test", "user": "root"},
+        "stages": {
+            "base": {"from": "debian:bookworm-slim", "steps": steps},
+            "development": {"from": "base"},
+            "production": {"from": "base"},
+        },
+        **extra,
+    }
+
+
+def test_no_cache_mount_by_default():
+    content = _generate(_config([{"apt-get": {"install": ["curl"]}}]))
+    assert "--mount=type=cache" not in content
+    # The normal cleanup is retained when caching is off.
+    assert "rm -rf /var/lib/apt/lists/*" in content
+
+
+def test_apt_cache_mount_when_enabled():
+    content = _generate(
+        _config([{"apt-get": {"install": ["curl", "git"]}}], cache_mounts=True)
+    )
+    assert "--mount=type=cache,target=/var/cache/apt,sharing=locked" in content
+    assert "--mount=type=cache,target=/var/lib/apt,sharing=locked" in content
+    # docker-clean is removed so downloaded debs persist in the cache mount.
+    assert "rm -f /etc/apt/apt.conf.d/docker-clean" in content
+    # the apt-list cleanup is dropped (the lists live in the cache mount now).
+    assert "rm -rf /var/lib/apt/lists/*" not in content
+
+
+def test_apt_cache_mount_is_a_single_run_with_mounts_first():
+    content = _generate(
+        _config([{"apt-get": {"install": ["curl"]}}], cache_mounts=True)
+    )
+    run_lines = [
+        line
+        for line in content.splitlines()
+        if line.lstrip().startswith("RUN --mount=type=cache,target=/var/cache/apt")
+    ]
+    assert len(run_lines) == 1
+    # install is still chained into the same RUN
+    assert "apt-get update" in content
+    assert "apt-get install -y --no-install-recommends curl" in content
+
+
+def test_pip_unaffected_by_cache_mounts():
+    # pip has no cache config yet, so enabling cache_mounts leaves it unchanged.
+    content = _generate(_config([{"pip": {"install": ["numpy"]}}], cache_mounts=True))
+    assert "--mount=type=cache" not in content
+    assert "--no-cache-dir" in content


### PR DESCRIPTION
Set `cache_mounts: true` and supported package-manager steps gain
[BuildKit cache mounts](https://docs.docker.com/build/cache/optimize/#use-cache-mounts),
so the package cache persists between builds (in the BuildKit cache, not the
image) and rebuilds re-use downloaded packages instead of refetching them.

Registry entries can declare a `cache` block - targets, an extra setup step,
and whether to drop the normal cleanup. With caching on, the generated RUN is
prefixed with the cache mounts, the extra setup is prepended, and the dropped
cleanup is omitted. For `apt-get`:

```dockerfile
RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
    --mount=type=cache,target=/var/lib/apt,sharing=locked \
    rm -f /etc/apt/apt.conf.d/docker-clean && apt-get update && \
    apt-get install -y --no-install-recommends ...
```

(`docker-clean` is removed so `.deb`s persist; the apt-list cleanup is skipped
because the lists now live in the cache mount.)

Scoped to `apt-get` for now - pip/apk/dnf run in *user* context and need cache
ownership handling that warrants its own change, so they're a deliberate
follow-up. Requires BuildKit (default in current Docker; supported by Podman).
Additive and opt-in - off by default, image size unaffected.