### PR TITLE
docs: surface the new opt-in features on the landing pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ Build and run the production image:
 * **Data volumes** - shorthand for sibling folders (`outputs`, `cache`) that persist across runs without entering the image
 * **AWS credential forwarding** - mount host AWS config into the container
 * **Cached assets** - download models and datasets once, reuse across builds
+* **Dev Container support** - generate `.devcontainer/devcontainer.json` to open the same image in VS Code or Codespaces
+* **Reproducible, cacheable builds** - opt-in base-image digest pinning and BuildKit cache mounts for faster, repeatable rebuilds
+* **Build secrets** - pass credentials at build time via BuildKit secret mounts, never baked into image layers
 
 ## Documentation
 
@@ -90,7 +93,7 @@ Full documentation is available at **[markhedleyjones.com/container-magic](https
 | Page | Contents |
 |------|----------|
 | [Getting Started](https://markhedleyjones.com/container-magic/getting-started/) | Installation, first project, workflow |
-| [Configuration](https://markhedleyjones.com/container-magic/configuration/) | Full YAML reference - names, runtime, stages, commands |
+| [Configuration](https://markhedleyjones.com/container-magic/configuration/) | Full YAML reference - names, runtime, stages, commands, build secrets, dev containers, digest pinning, cache mounts |
 | [Build Steps](https://markhedleyjones.com/container-magic/build-steps/) | Package managers, custom commands, layer caching |
 | [Cached Assets](https://markhedleyjones.com/container-magic/cached-assets/) | Asset downloading, caching, and cache management |
 | [User Handling](https://markhedleyjones.com/container-magic/user-handling/) | Dev vs prod users, copy ownership, permissions |

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,7 +24,7 @@ For development, `cm build` and `cm run` read the YAML config directly and handl
 ## Quick Start
 
 ```bash
-# Install
+# Install (or, on Nix: nix profile install github:markhedleyjones/container-magic)
 pip install container-magic
 
 # Create a new project
@@ -51,3 +51,6 @@ See [Getting Started](getting-started.md) for a full walkthrough.
 * **Multi-stage builds** - Separate base, development, and production stages
 * **Live workspace mounting** - Edit code on host, run in container (development)
 * **Standalone scripts** - Production needs only docker/podman (no dependencies)
+* **Dev Container support** - Generate `.devcontainer/devcontainer.json` for VS Code / Codespaces
+* **Reproducible, cacheable builds** - Opt-in base-image digest pinning and BuildKit cache mounts
+* **Build secrets** - Pass credentials at build time, never baked into image layers


### PR DESCRIPTION
The README and docs index feature lists predated the four features shipped in
5.5.0-5.8.0, so the headline surfaces didn't mention them (the full reference
in `configuration.md` already covers each).

- README + docs index **Key Features**: add Dev Container support; reproducible,
  cacheable builds (digest pinning + cache mounts); and build secrets.
- README Documentation table: point the Configuration row at the new sections.
- docs index Quick Start: add the Nix install option (parity with the README).

Docs only - no release. `mkdocs build --strict` passes.