### PR TITLE
docs: cross-reference cache_mounts from the package-installation section

### DIFF
--- a/docs/build-steps.md
+++ b/docs/build-steps.md
@@ -357,6 +357,10 @@ If no steps are specified, `copy: workspace` is added automatically.
 
 Package managers can be used as structured steps. The command name determines which package manager is used:
 
+!!! tip
+    Enable [`cache_mounts`](configuration.md#cache-mounts) to persist downloaded
+    packages between builds for faster rebuilds (currently `apt-get`).
+
 ```yaml
 # Debian / Ubuntu
 steps:


### PR DESCRIPTION
Adds a tip in the Package Installation section pointing to the `cache_mounts` config, so someone configuring apt/pip discovers the build-cache option where they'd look for it. Docs only - no release. mkdocs --strict passes.