### PR TITLE
feat(config): stage-level entrypoint and cmd fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Build and run the production image:
 * **Automatic user handling** - host user identity in dev, dedicated user in prod, no manual setup
 * **GPU, display, and audio** - NVIDIA GPU passthrough, X11/Wayland forwarding, PulseAudio/PipeWire
 * **Custom commands** - define once, use in both dev and prod with port publishing and environment variables
+* **Production entrypoint** - set a stage's `entrypoint` and `cmd` from a plain string or list, emitted as signal-safe exec form
 * **Multi-stage builds** - share steps between stages, pip packages install into the base image's Python (no venv duplication)
 * **Transparent execution** - run commands from anywhere in your repo with automatic path translation
 * **Data volumes** - shorthand for sibling folders (`outputs`, `cache`) that persist across runs without entering the image
@@ -93,7 +94,7 @@ Full documentation is available at **[markhedleyjones.com/container-magic](https
 | Page | Contents |
 |------|----------|
 | [Getting Started](https://markhedleyjones.com/container-magic/getting-started/) | Installation, first project, workflow |
-| [Configuration](https://markhedleyjones.com/container-magic/configuration/) | Full YAML reference - names, runtime, stages, commands, build secrets, dev containers, digest pinning, cache mounts |
+| [Configuration](https://markhedleyjones.com/container-magic/configuration/) | Full YAML reference - names, runtime, stages, entrypoint/cmd, commands, build secrets, dev containers, digest pinning, cache mounts |
 | [Build Steps](https://markhedleyjones.com/container-magic/build-steps/) | Package managers, custom commands, layer caching |
 | [Cached Assets](https://markhedleyjones.com/container-magic/cached-assets/) | Asset downloading, caching, and cache management |
 | [User Handling](https://markhedleyjones.com/container-magic/user-handling/) | Dev vs prod users, copy ownership, permissions |

--- a/docs/build-steps.md
+++ b/docs/build-steps.md
@@ -216,6 +216,8 @@ steps:
 
 This means you can write steps concisely -- just write the command and container-magic adds the `RUN` for you.
 
+To set the container's entrypoint or default command, prefer the structured [`entrypoint` / `cmd` stage fields](configuration.md#entrypoint-and-command) over a raw `ENTRYPOINT` / `CMD` passthrough step: they accept a plain string or list, always emit exec form, and live on the stage rather than in the step order.
+
 ### Multi-command Steps
 
 Use `run:` with a list to combine multiple commands into a **single `RUN` instruction** (and therefore a single Docker layer). Commands are automatically joined with `&& \`:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -297,6 +297,7 @@ Each stage also supports:
 
 - `distro` - Override the auto-detected distribution family. Sets package manager, user creation style, and interactive shell in one field. Inherited by child stages. Useful when using a custom or locally-built base image whose name doesn't match a known distribution. Supported values: `alpine`, `debian`, `ubuntu`, `fedora`, `centos`, `rhel`, `rocky`, `alma`. Unrecognised values warn and default to Debian settings.
 - `package_manager` - Override the package manager (`apt`, `apk`, or `dnf`). Takes precedence over `distro` if both are set.
+- `entrypoint` / `cmd` - The container's entrypoint and default command. See [Entrypoint and command](#entrypoint-and-command).
 
 Package installation uses the command builder step syntax. The command name determines which package manager is used. Container-optimised defaults (flags, cleanup) are applied automatically - see [Package Installation](build-steps.md#package-installation) for details.
 
@@ -331,6 +332,39 @@ steps:
 ```
 
 You can use any image from Docker Hub as your base (e.g., `python:3.11`, `ubuntu:22.04`, `pytorch/pytorch`, `nvidia/cuda:12.4.0-runtime-ubuntu22.04`).
+
+### Entrypoint and command
+
+Set what a production image runs when started. Both fields live on the stage, so the production stage can define an entrypoint while development stays an interactive shell.
+
+```yaml
+stages:
+  production:
+    from: base
+    steps:
+      - copy: workspace
+    entrypoint: python workspace/app.py
+    cmd: ["--port", "8080"]
+```
+
+Generates:
+
+```dockerfile
+ENTRYPOINT ["python", "workspace/app.py"]
+CMD ["--port", "8080"]
+```
+
+- `entrypoint` - the executable the container always runs.
+- `cmd` - default arguments appended to the entrypoint; overridable at `docker run myimage <args>`. Used on its own (without an entrypoint), `cmd` is the default command.
+
+Each accepts either form:
+
+- A **string** is split with shell-style quoting: `entrypoint: sh -c "echo hi"` becomes `["sh", "-c", "echo hi"]`.
+- A **list** is used verbatim: `cmd: ["--port", "8080"]`.
+
+Both are always emitted in **exec form** (the JSON-array form). The process runs as the container's PID 1 and receives Unix signals directly, so `docker stop` reaches it for a graceful shutdown. Shell form (`/bin/sh -c ...`, which does not forward signals) is deliberately not generated; if you need shell features such as environment-variable expansion at runtime, wrap the command yourself: `entrypoint: ["sh", "-c", "exec myapp --port $PORT"]`.
+
+Paths are relative to the working directory, which is the user's home (`$WORKSPACE` points at the copied workspace, e.g. `/home/<user>/workspace`). Reference the workspace explicitly (`python workspace/app.py`) or add a `WORKDIR ${WORKSPACE}` step before setting the entrypoint.
 
 ## Commands
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -47,6 +47,7 @@ See [Getting Started](getting-started.md) for a full walkthrough.
 * **YAML configuration** - Single source of truth for your container setup
 * **Transparent execution** - Run commands in container from anywhere in your repo
 * **Custom commands** - Define commands once, use in both dev and prod
+* **Production entrypoint** - Set a stage's `entrypoint` and `cmd` from a string or list, emitted as signal-safe exec form
 * **Smart features** - GPU, display (X11/Wayland), audio, and AWS credential support
 * **Multi-stage builds** - Separate base, development, and production stages
 * **Live workspace mounting** - Edit code on host, run in container (development)

--- a/src/container_magic/core/config.py
+++ b/src/container_magic/core/config.py
@@ -278,6 +278,17 @@ class StageConfig(BaseModel):
         description="Stage-specific runtime overrides. Scalars override the global runtime; "
         "lists (volumes, devices, features) are appended to the global values.",
     )
+    entrypoint: Optional[Union[str, List[str]]] = Field(
+        default=None,
+        description="Container entrypoint. A string is split with shell-style quoting; "
+        "a list is used verbatim. Always emitted as ENTRYPOINT in exec form so the "
+        "process runs as PID 1 and receives signals.",
+    )
+    cmd: Optional[Union[str, List[str]]] = Field(
+        default=None,
+        description="Default command/arguments, overridable at `docker run`. A string is "
+        "split with shell-style quoting; a list is used verbatim. Emitted as CMD in exec form.",
+    )
 
     @model_validator(mode="before")
     @classmethod
@@ -292,6 +303,17 @@ class StageConfig(BaseModel):
                 "The shell field sets the interactive shell for cm run and run.sh."
             )
         return data
+
+    @field_validator("entrypoint", "cmd")
+    @classmethod
+    def validate_exec_form(cls, v, info):
+        """Reject empty or malformed entrypoint/cmd values at load time."""
+        if v is None:
+            return v
+        from container_magic.core.steps import render_exec_form
+
+        render_exec_form(v, info.field_name)
+        return v
 
 
 class MountSpec(BaseModel):

--- a/src/container_magic/core/steps.py
+++ b/src/container_magic/core/steps.py
@@ -17,7 +17,9 @@ Three step categories determined by YAML structure:
 """
 
 import difflib
+import json
 import re
+import shlex
 from typing import Any, Dict, List, Optional, Union
 
 from container_magic.core.registry import RegistryEntry
@@ -71,6 +73,28 @@ _DOCKERFILE_INSTRUCTIONS = {
     "VOLUME",
     "WORKDIR",
 }
+
+
+def render_exec_form(value: Union[str, List[Any]], field_name: str = "value") -> str:
+    """Render an entrypoint/cmd value as a Dockerfile exec-form JSON array.
+
+    A string is split into tokens with shell-style quoting (``shlex``); a list
+    is used verbatim. The result is always exec form (a JSON array) so the
+    process runs as the container's PID 1 and receives Unix signals directly,
+    unlike shell form which wraps the command in ``/bin/sh -c``.
+    """
+    if isinstance(value, str):
+        tokens = shlex.split(value)
+    elif isinstance(value, list):
+        tokens = [str(item) for item in value]
+    else:
+        raise ValueError(
+            f"{field_name} must be a string or list of strings, "
+            f"got {type(value).__name__}"
+        )
+    if not tokens:
+        raise ValueError(f"{field_name} must not be empty")
+    return json.dumps(tokens)
 
 
 def quote_arg(arg: str) -> str:

--- a/src/container_magic/generators/dockerfile.py
+++ b/src/container_magic/generators/dockerfile.py
@@ -13,7 +13,11 @@ from container_magic.core.config import (
     StageConfig,
 )
 from container_magic.core.registry import load_registry
-from container_magic.core.steps import has_create_user_in_stages, parse_step
+from container_magic.core.steps import (
+    has_create_user_in_stages,
+    parse_step,
+    render_exec_form,
+)
 from container_magic.core.symlinks import scan_workspace_symlinks
 from container_magic.core.templates import (
     detect_package_manager,
@@ -538,6 +542,13 @@ def generate_dockerfile(
 
         needs_user_args = _stage_needs_user_args(ordered_steps)
 
+        entrypoint = (
+            render_exec_form(stage_config.entrypoint, "entrypoint")
+            if stage_config.entrypoint
+            else None
+        )
+        cmd = render_exec_form(stage_config.cmd, "cmd") if stage_config.cmd else None
+
         stages_data.append(
             {
                 "name": stage_name,
@@ -551,6 +562,8 @@ def generate_dockerfile(
                 "user_home": user_home,
                 "ordered_steps": ordered_steps,
                 "needs_user_args": needs_user_args,
+                "entrypoint": entrypoint,
+                "cmd": cmd,
             }
         )
 

--- a/src/container_magic/templates/Dockerfile.j2
+++ b/src/container_magic/templates/Dockerfile.j2
@@ -139,4 +139,13 @@ RUN {{ step.command }}
 {% endif %}
 {% endif %}
 {% endfor %}
+{% if stage.entrypoint or stage.cmd %}
+
+{% endif %}
+{% if stage.entrypoint %}
+ENTRYPOINT {{ stage.entrypoint }}
+{% endif %}
+{% if stage.cmd %}
+CMD {{ stage.cmd }}
+{% endif %}
 {% endfor %}

--- a/tests/fixtures/configs/scenario_entrypoint.yaml
+++ b/tests/fixtures/configs/scenario_entrypoint.yaml
@@ -1,0 +1,20 @@
+# Scenario: production image with a configured entrypoint and cmd
+# Tests: entrypoint/cmd emitted as exec form, workspace-relative path runs
+names:
+  image: cm-scenario-entrypoint
+  workspace: workspace
+  user: appuser
+
+stages:
+  base:
+    from: cm-test:debian
+
+  development:
+    from: base
+
+  production:
+    from: base
+    steps:
+      - copy: workspace
+    entrypoint: python3 workspace/entrypoint_app.py
+    cmd: ["default-arg"]

--- a/tests/fixtures/workspace_scripts/entrypoint_app.py
+++ b/tests/fixtures/workspace_scripts/entrypoint_app.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python3
+"""Print a marker and any args; verifies the configured entrypoint runs."""
+
+import sys
+
+print("entrypoint_ran")
+print(f"args: {' '.join(sys.argv[1:])}")

--- a/tests/integration/test_scenarios.py
+++ b/tests/integration/test_scenarios.py
@@ -189,3 +189,52 @@ def test_custom_command_pipefail_propagates(debian_base_image, tmp_path):
         f"succeeding command should still exit 0, got {passing.returncode}\n"
         f"stderr: {passing.stderr}"
     )
+
+
+def test_entrypoint_and_cmd(debian_base_image, tmp_path):
+    """Production image runs its configured entrypoint with cmd as default args.
+
+    Verifies the entrypoint resolves the workspace-relative path, the cmd
+    supplies default arguments, and a runtime argument overrides the cmd.
+    """
+    image = "cm-scenario-entrypoint:latest"
+    project = _setup_project(
+        tmp_path, "scenario_entrypoint.yaml", ["entrypoint_app.py"]
+    )
+    _build_and_run(project)  # build only
+
+    dockerfile = (project / "Dockerfile").read_text()
+    assert 'ENTRYPOINT ["python3", "workspace/entrypoint_app.py"]' in dockerfile
+    assert 'CMD ["default-arg"]' in dockerfile
+
+    try:
+        default_run = subprocess.run(
+            [_runtime(), "run", "--rm", image],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        assert default_run.returncode == 0, (
+            f"entrypoint run failed:\nstdout: {default_run.stdout}\n"
+            f"stderr: {default_run.stderr}"
+        )
+        assert "entrypoint_ran" in default_run.stdout
+        assert "args: default-arg" in default_run.stdout
+
+        override_run = subprocess.run(
+            [_runtime(), "run", "--rm", image, "override-arg"],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        assert override_run.returncode == 0, (
+            f"entrypoint run with override failed:\nstderr: {override_run.stderr}"
+        )
+        assert "args: override-arg" in override_run.stdout
+    finally:
+        subprocess.run(
+            [_runtime(), "rmi", "-f", image],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -550,3 +550,50 @@ class TestEffectiveRuntime:
         assert dev_rt.network_mode == "host"
         prod_rt = config.effective_runtime("production")
         assert prod_rt.network_mode == "bridge"
+
+
+def _config_with_stage_fields(**production_fields):
+    return ContainerMagicConfig(
+        names={"image": "test", "workspace": "workspace", "user": "root"},
+        stages={
+            "base": {"from": "debian:bookworm-slim"},
+            "development": {"from": "base"},
+            "production": {"from": "base", **production_fields},
+        },
+    )
+
+
+def test_entrypoint_string_accepted():
+    config = _config_with_stage_fields(entrypoint="python app.py")
+    assert config.stages["production"].entrypoint == "python app.py"
+
+
+def test_entrypoint_list_accepted():
+    config = _config_with_stage_fields(entrypoint=["python", "app.py"])
+    assert config.stages["production"].entrypoint == ["python", "app.py"]
+
+
+def test_cmd_accepted():
+    config = _config_with_stage_fields(cmd=["--port", "8080"])
+    assert config.stages["production"].cmd == ["--port", "8080"]
+
+
+def test_empty_string_entrypoint_rejected():
+    with pytest.raises(ValidationError, match="entrypoint must not be empty"):
+        _config_with_stage_fields(entrypoint="   ")
+
+
+def test_empty_list_entrypoint_rejected():
+    with pytest.raises(ValidationError, match="entrypoint must not be empty"):
+        _config_with_stage_fields(entrypoint=[])
+
+
+def test_empty_list_cmd_rejected():
+    with pytest.raises(ValidationError, match="cmd must not be empty"):
+        _config_with_stage_fields(cmd=[])
+
+
+def test_entrypoint_omitted_by_default():
+    config = _config_with_stage_fields()
+    assert config.stages["production"].entrypoint is None
+    assert config.stages["production"].cmd is None

--- a/tests/unit/test_dockerfile_output.py
+++ b/tests/unit/test_dockerfile_output.py
@@ -471,3 +471,81 @@ class TestEnvMerging:
         for line in content.splitlines():
             if "MY_VAR" in line:
                 assert "\\" not in line
+
+
+# ---------------------------------------------------------------------------
+# Entrypoint / Cmd
+# ---------------------------------------------------------------------------
+
+
+def _stage_config(stage, **fields):
+    """Minimal valid config with extra fields applied to a named stage."""
+    config = {
+        "names": {"image": "test", "workspace": "workspace", "user": "root"},
+        "stages": {
+            "base": {"from": "debian:bookworm-slim"},
+            "development": {"from": "base", "steps": []},
+            "production": {"from": "base", "steps": []},
+        },
+    }
+    config["stages"][stage].update(fields)
+    return config
+
+
+class TestEntrypointCmd:
+    def test_string_entrypoint_renders_exec_form(self):
+        config = _stage_config("production", entrypoint="python app.py")
+        content = _generate(config)
+        prod = _get_stage_block(content, "production")
+        assert 'ENTRYPOINT ["python", "app.py"]' in prod
+
+    def test_list_entrypoint_renders_exec_form(self):
+        config = _stage_config("production", entrypoint=["python", "app.py"])
+        content = _generate(config)
+        prod = _get_stage_block(content, "production")
+        assert 'ENTRYPOINT ["python", "app.py"]' in prod
+
+    def test_string_with_quotes_split_respecting_shell_quoting(self):
+        config = _stage_config("production", entrypoint='sh -c "echo hi there"')
+        content = _generate(config)
+        prod = _get_stage_block(content, "production")
+        assert 'ENTRYPOINT ["sh", "-c", "echo hi there"]' in prod
+
+    def test_cmd_list_renders_exec_form(self):
+        config = _stage_config("production", cmd=["--port", "8080"])
+        content = _generate(config)
+        prod = _get_stage_block(content, "production")
+        assert 'CMD ["--port", "8080"]' in prod
+
+    def test_entrypoint_and_cmd_together(self):
+        config = _stage_config("production", entrypoint="/start.sh", cmd=["--verbose"])
+        content = _generate(config)
+        prod = _get_stage_block(content, "production")
+        assert 'ENTRYPOINT ["/start.sh"]' in prod
+        assert 'CMD ["--verbose"]' in prod
+
+    def test_entrypoint_emitted_after_final_user(self):
+        """ENTRYPOINT comes after the build steps / USER switch, at stage end."""
+        config = {
+            "names": {"image": "test", "workspace": "workspace", "user": "nonroot"},
+            "stages": {
+                "base": {"from": "debian:bookworm-slim"},
+                "development": {"from": "base", "steps": []},
+                "production": {
+                    "from": "base",
+                    "steps": [{"copy": "workspace"}],
+                    "entrypoint": ["python", "workspace/app.py"],
+                },
+            },
+        }
+        content = _generate(config)
+        prod = _get_stage_block(content, "production")
+        user_idx = prod.rindex("USER ")
+        entry_idx = prod.index("ENTRYPOINT")
+        assert entry_idx > user_idx
+
+    def test_no_entrypoint_emits_nothing(self):
+        config = _stage_config("production", steps=[])
+        content = _generate(config)
+        assert "ENTRYPOINT" not in content
+        assert "\nCMD " not in content


### PR DESCRIPTION
Stages gain `entrypoint` and `cmd` fields so production images can set their runtime command directly, instead of hand-writing a raw `ENTRYPOINT`/`CMD` passthrough step.

```yaml
stages:
  production:
    from: base
    steps:
      - copy: workspace
    entrypoint: python workspace/app.py    # string -> shlex-split
    cmd: ["--port", "8080"]                 # list -> verbatim
```

generates

```dockerfile
ENTRYPOINT ["python", "workspace/app.py"]
CMD ["--port", "8080"]
```

Behaviour:

- A string is split with shell-style quoting; a list is used verbatim.
- Both are always emitted in exec form, so the process runs as PID 1 and receives Unix signals (`docker stop` reaches it). Shell form is deliberately not generated; use `entrypoint: ["sh", "-c", "exec app --port $PORT"]` if runtime shell expansion is needed. The raw passthrough step still works for anyone who wants it.
- Each field lives on the stage, so production can define an entrypoint while development stays an interactive shell. Omitted fields emit nothing and are dropped from the scaffold.
- Empty values are rejected at config-load time.

The field is named `cmd` (not `command`) to avoid colliding with the existing custom-commands feature (`commands:`), and to pair 1:1 with the `entrypoint` field and their `CMD`/`ENTRYPOINT` instructions.

Documented in the configuration reference, cross-referenced from the build-steps passthrough section, and surfaced on both landing pages. Covered by unit tests (exec-form rendering, validation, placement) and an end-to-end integration test that builds a production image and runs its configured entrypoint.